### PR TITLE
Add delete cards from cardsHistory

### DIFF
--- a/src/lib/components/blocks/confirmation-dialog.tsx
+++ b/src/lib/components/blocks/confirmation-dialog.tsx
@@ -1,0 +1,46 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '../ui/alert-dialog';
+import { ReactNode } from 'react';
+
+interface ConfirmationDialogProps {
+  trigger: ReactNode;
+  title: string;
+  description: string;
+  onConfirm: () => void;
+  confirmLabel?: string;
+}
+
+export default function ConfirmationDialog({
+  trigger,
+  title,
+  description,
+  onConfirm,
+  confirmLabel = 'Confirm',
+}: ConfirmationDialogProps) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/lib/components/card-history/card-history-item.tsx
+++ b/src/lib/components/card-history/card-history-item.tsx
@@ -1,0 +1,50 @@
+import { Button } from '../ui/button';
+import { BingoCard } from '../bingo/bingo-card';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardFooter,
+} from '../ui/card';
+import { BingoCardType } from '@/lib/domain/card/types';
+import ConfirmationDialog from '../blocks/confirmation-dialog';
+
+interface CardHistoryItemProps {
+  card: BingoCardType;
+  onOpen: () => void;
+  onDelete: () => void;
+}
+
+export default function CardHistoryItem({
+  card,
+  onOpen,
+  onDelete,
+}: CardHistoryItemProps) {
+  return (
+    <Card className="w-fit">
+      <CardHeader>
+        <CardTitle>{card.title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <BingoCard disabled items={card.items} />
+      </CardContent>
+      <CardFooter className="gap-2">
+        <ConfirmationDialog
+          trigger={
+            <Button className="w-full" variant="destructive">
+              Delete
+            </Button>
+          }
+          title={`Are you sure you want to delete ${card.title}?`}
+          description="This action will remove card forever and can't be undone"
+          onConfirm={onDelete}
+          confirmLabel="Delete"
+        />
+        <Button className="w-full" variant="secondary" onClick={onOpen}>
+          Open
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/lib/components/card-history/card-history-list.tsx
+++ b/src/lib/components/card-history/card-history-list.tsx
@@ -1,27 +1,20 @@
 import { BingoCardType } from '@/lib/domain/card/types';
-import { Button } from '../ui/button';
-import { BingoCard } from '../bingo/bingo-card';
-import {
-  Card,
-  CardAction,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from '../ui/card';
 import VirtualizedList from '../ui/virtualized-list';
 import { useNavigate } from 'react-router-dom';
 import { useBoundStore } from '@/lib/zustand/store';
 import { useShallow } from 'zustand/react/shallow';
 import { encodeCardToParams } from '../bingo/generate-button';
+import CardHistoryItem from './card-history-item';
 
 interface CardHistoryListProps {
   cards: BingoCardType[];
 }
 
 export default function CardHistoryList({ cards }: CardHistoryListProps) {
-  const { setCard } = useBoundStore(
+  const { setCard, removeFromCardsHistory } = useBoundStore(
     useShallow((state) => ({
       setCard: state.setCard,
+      removeFromCardsHistory: state.removeFromCardsHistory,
     }))
   );
   const navigate = useNavigate();
@@ -35,27 +28,16 @@ export default function CardHistoryList({ cards }: CardHistoryListProps) {
     <div className="flex-1 flex justify-center min-h-0 w-full">
       <VirtualizedList
         count={cards.length}
-        estimateSize={524}
+        estimateSize={596}
         renderItem={(index) => {
           const card = cards[index];
           return (
             <div className="flex justify-center px-4">
-              <Card className="w-fit">
-                <CardHeader>
-                  <CardTitle>{card.title}</CardTitle>
-                  <CardAction>
-                    <Button
-                      variant="secondary"
-                      onClick={() => handleNavigate(card)}
-                    >
-                      Open
-                    </Button>
-                  </CardAction>
-                </CardHeader>
-                <CardContent>
-                  <BingoCard disabled items={card.items} />
-                </CardContent>
-              </Card>
+              <CardHistoryItem
+                card={card}
+                onOpen={() => handleNavigate(card)}
+                onDelete={() => removeFromCardsHistory(index)}
+              />
             </div>
           );
         }}

--- a/src/lib/components/card-history/cards-history-empty-state.tsx
+++ b/src/lib/components/card-history/cards-history-empty-state.tsx
@@ -1,0 +1,9 @@
+export default function CardsHistoryEmptyState() {
+  return (
+    <p className="max-w-xl text-center">
+      An <span className="text-violet-500 dark:text-violet-400">Enderman</span>{' '}
+      was here. Your cards have been teleported to another dimension. Go play
+      some rounds to get them back!
+    </p>
+  );
+}

--- a/src/lib/components/items/reset-items-button.tsx
+++ b/src/lib/components/items/reset-items-button.tsx
@@ -1,41 +1,23 @@
 import { useBoundStore } from '@/lib/zustand/store';
 import { Button } from '../ui/button';
 import { Icon } from '@iconify/react/dist/iconify.js';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '../ui/alert-dialog';
+import ConfirmationDialog from '../blocks/confirmation-dialog';
 
 export default function ResetItemsButton() {
   const { resetItems } = useBoundStore();
 
   return (
-    <AlertDialog>
-      <AlertDialogTrigger asChild>
+    <ConfirmationDialog
+      trigger={
         <Button size="icon" variant="destructive">
           <Icon width={24} icon="heroicons:arrow-path-16-solid" />
         </Button>
-      </AlertDialogTrigger>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Reset all items?</AlertDialogTitle>
-          <AlertDialogDescription>
-            This action will remove all current items and restore the list to
-            its initial state. The change cannot be undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={resetItems}>Reset</AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+      }
+      title="Reset all items?"
+      description="This action will remove all current items and restore the list to
+      its initial state. The change cannot be undone."
+      onConfirm={resetItems}
+      confirmLabel="Reset"
+    />
   );
 }

--- a/src/lib/zustand/cardsHistorySlice.ts
+++ b/src/lib/zustand/cardsHistorySlice.ts
@@ -4,6 +4,7 @@ import { BingoCardType } from '../domain/card/types';
 export type CardsHistorySlice = {
   cardsHistory: BingoCardType[];
   addToCardsHistory: (card: BingoCardType) => void;
+  removeFromCardsHistory: (index: number) => void;
 };
 
 export const createCardHistorySlice: StateCreator<CardsHistorySlice> = (
@@ -14,4 +15,9 @@ export const createCardHistorySlice: StateCreator<CardsHistorySlice> = (
     set((state) => ({
       cardsHistory: [card, ...state.cardsHistory],
     })),
+  removeFromCardsHistory: (index: number) => {
+    set((state) => ({
+      cardsHistory: state.cardsHistory.filter((_, i) => i !== index),
+    }));
+  },
 });


### PR DESCRIPTION
## What was done
- Add delete button to each card in `cardHistory`
- Deleting a card removes it immediately from localStorage and UI
- Confirmation dialog appears before deleting
- Extract `ConfirmationDialog` as a reusable block for actions requiring confirmation
- Extract `CardHistoryItem` as a separate component for better flexibility