### PR TITLE
Rename 'favourite' to 'isFavorited' in card types

### DIFF
--- a/src/lib/components/bingo/generate-button.tsx
+++ b/src/lib/components/bingo/generate-button.tsx
@@ -35,7 +35,7 @@ export const GenerateButton = () => {
     addToCardsHistory({
       items: generatedCard,
       title: `Card #${cardsHistory.length + 1}`,
-      favourite: false,
+      isFavorited: false,
     });
     const link = encodeCardToParams(generatedCard);
     setSearchParams(link);

--- a/src/lib/domain/card/types.ts
+++ b/src/lib/domain/card/types.ts
@@ -3,5 +3,5 @@ import { Item } from '../items/types';
 export type BingoCardType = {
   items: Item[];
   title: string;
-  favourite: boolean;
+  isFavorited: boolean;
 };

--- a/src/lib/zustand/cardSlice.ts
+++ b/src/lib/zustand/cardSlice.ts
@@ -1,10 +1,9 @@
 import type { StateCreator } from 'zustand';
 
 import { Item } from '../domain/items/types';
-import { BingoCardType } from '../domain/card/types';
 
 export type CardSlice = {
-  card: BingoCardType;
+  card: { items: Item[]; title: string };
   setCard: (items: Item[]) => void;
 };
 
@@ -12,7 +11,6 @@ export const createCardSlice: StateCreator<CardSlice> = (set) => ({
   card: {
     items: [],
     title: '',
-    favourite: false,
   },
   setCard: (items: Item[]) =>
     set((state) => ({


### PR DESCRIPTION
## What
Renames `favourite` → `isFavorited` on `BingoCardType` and removes the field from the transient `CardSlice`.

## Why
Foundation for the card favorites feature — establishes the correct field name and ensures it only lives where it belongs (persisted history, not the active card).

## How
- `isFavorited` added to `BingoCardType` in `types.ts`; defaults to `false` in `generate-button.tsx`
- `CardSlice` inlined to `{ items: Item[]; title: string }` and `BingoCardType` import dropped — the active card has no concept of favoriting
- No migration needed: old cards without the field are falsy, which is the correct unfavorited default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved naming consistency for card favoriting functionality
  * Optimized internal card state management structure for better maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->