### PR TITLE
Add favourite functionality to bingo cards

### DIFF
--- a/src/lib/components/bingo/bingo-card.tsx
+++ b/src/lib/components/bingo/bingo-card.tsx
@@ -2,13 +2,24 @@ import { useState } from 'react';
 import { Item } from '@/lib/domain/items/types';
 
 import { Cell } from '../ui/cell';
+import { Button } from '../ui/button';
+import { Icon } from '@iconify/react/dist/iconify.js';
 
 type BingoCardProps = {
   disabled?: boolean;
   items: Item[];
+  title?: string;
+  isFavourite?: boolean;
+  onToggleFavourite?: () => void;
 };
 
-export const BingoCard = ({ disabled, items }: BingoCardProps) => {
+export const BingoCard = ({
+  disabled,
+  items,
+  title,
+  isFavourite,
+  onToggleFavourite,
+}: BingoCardProps) => {
   const [selectedCell, setSelectedCell] = useState<string[]>([]);
 
   const handleCellClick = (cellId: string) => {
@@ -22,16 +33,38 @@ export const BingoCard = ({ disabled, items }: BingoCardProps) => {
   };
 
   return (
-    <div className="grid aspect-square w-full grid-cols-5 grid-rows-5 gap-2">
-      {items.map((item: Item) => (
-        <Cell
-          key={item.id}
-          item={item}
-          checked={selectedCell.includes(item.id)}
-          onClick={() => handleCellClick(item.id)}
-          disabled={disabled}
-        />
-      ))}
+    <div className="relative space-y-2 w-full">
+      {(title || onToggleFavourite) && (
+        <div className="flex items-center justify-between">
+          {title && <h3 className="text-lg font-semibold">{title}</h3>}
+          {onToggleFavourite && (
+            <Button
+              variant="secondary"
+              size="icon"
+              onClick={onToggleFavourite}
+              aria-label={isFavourite ? 'Unfavourite card' : 'Favourite card'}
+            >
+              <Icon
+                className="text-2xl"
+                icon={
+                  isFavourite ? 'heroicons:star-16-solid' : 'heroicons:star'
+                }
+              />
+            </Button>
+          )}
+        </div>
+      )}
+      <div className="grid aspect-square w-full grid-cols-5 grid-rows-5 gap-2">
+        {items.map((item: Item) => (
+          <Cell
+            key={item.id}
+            item={item}
+            checked={selectedCell.includes(item.id)}
+            onClick={() => handleCellClick(item.id)}
+            disabled={disabled}
+          />
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/lib/components/card-history/card-history-item.tsx
+++ b/src/lib/components/card-history/card-history-item.tsx
@@ -9,25 +9,38 @@ import {
 } from '../ui/card';
 import { BingoCardType } from '@/lib/domain/card/types';
 import ConfirmationDialog from '../blocks/confirmation-dialog';
+import { useBoundStore } from '@/lib/zustand/store';
+import { useShallow } from 'zustand/react/shallow';
+import { Icon } from '@iconify/react';
 
 interface CardHistoryItemProps {
   card: BingoCardType;
   onOpen: () => void;
   onDelete: () => void;
+  index: number;
 }
 
 export default function CardHistoryItem({
   card,
   onOpen,
   onDelete,
+  index,
 }: CardHistoryItemProps) {
+  const { toggleFavourite } = useBoundStore(
+    useShallow((state) => ({
+      toggleFavourite: state.toggleFavourite,
+    }))
+  );
   return (
     <Card className="w-fit">
-      <CardHeader>
-        <CardTitle>{card.title}</CardTitle>
-      </CardHeader>
       <CardContent>
-        <BingoCard disabled items={card.items} />
+        <BingoCard
+          disabled
+          title={card.title}
+          items={card.items}
+          isFavourite={card.isFavorited}
+          onToggleFavourite={() => toggleFavourite(index)}
+        />
       </CardContent>
       <CardFooter className="gap-2">
         <ConfirmationDialog

--- a/src/lib/components/card-history/card-history-list.tsx
+++ b/src/lib/components/card-history/card-history-list.tsx
@@ -35,6 +35,7 @@ export default function CardHistoryList({ cards }: CardHistoryListProps) {
             <div className="flex justify-center px-4">
               <CardHistoryItem
                 card={card}
+                index={index}
                 onOpen={() => handleNavigate(card)}
                 onDelete={() => removeFromCardsHistory(index)}
               />

--- a/src/lib/pages/home/index.tsx
+++ b/src/lib/pages/home/index.tsx
@@ -18,11 +18,12 @@ import IconLink from '@/lib/components/ui/icon-link';
 export default function Home() {
   const [searchParams] = useSearchParams();
   const hideControls = searchParams.get('show-controls') !== null;
-  const { items, card, setCard } = useBoundStore(
+  const { items, card, setCard, toggleCurrentCardFavourite } = useBoundStore(
     useShallow((state) => ({
       items: state.items,
       card: state.card,
       setCard: state.setCard,
+      toggleCurrentCardFavourite: state.toggleCurrentCardFavourite,
     }))
   );
 
@@ -50,8 +51,12 @@ export default function Home() {
         right={<IconLink to="/cards-history" icon="heroicons-clock-16-solid" />}
       />
       <div className="z-0 flex h-full w-full max-w-xl  flex-1 flex-col items-center justify-center gap-6 px-4">
-        <h1 className="text-2xl">Bingo card generator</h1>
-        <BingoCard items={card.items} />
+        <BingoCard
+          title={card.title}
+          items={card.items}
+          isFavourite={card.isFavorited}
+          onToggleFavourite={toggleCurrentCardFavourite}
+        />
         {!hideControls && (
           <div className="flex w-full flex-row items-center justify-end gap-2">
             <div className="w-full">

--- a/src/lib/zustand/cardSlice.ts
+++ b/src/lib/zustand/cardSlice.ts
@@ -3,20 +3,30 @@ import type { StateCreator } from 'zustand';
 import { Item } from '../domain/items/types';
 
 export type CardSlice = {
-  card: { items: Item[]; title: string };
+  card: { items: Item[]; title: string; isFavorited: boolean };
   setCard: (items: Item[]) => void;
+  toggleCurrentCardFavourite: () => void;
 };
 
 export const createCardSlice: StateCreator<CardSlice> = (set) => ({
   card: {
     items: [],
     title: '',
+    isFavorited: false,
   },
   setCard: (items: Item[]) =>
     set((state) => ({
       card: {
         ...state.card,
         items,
+        isFavorited: false,
+      },
+    })),
+  toggleCurrentCardFavourite: () =>
+    set((state) => ({
+      card: {
+        ...state.card,
+        isFavorited: !state.card.isFavorited,
       },
     })),
 });

--- a/src/lib/zustand/cardsHistorySlice.ts
+++ b/src/lib/zustand/cardsHistorySlice.ts
@@ -5,6 +5,7 @@ export type CardsHistorySlice = {
   cardsHistory: BingoCardType[];
   addToCardsHistory: (card: BingoCardType) => void;
   removeFromCardsHistory: (index: number) => void;
+  toggleFavourite: (index: number) => void;
 };
 
 export const createCardHistorySlice: StateCreator<CardsHistorySlice> = (
@@ -18,6 +19,13 @@ export const createCardHistorySlice: StateCreator<CardsHistorySlice> = (
   removeFromCardsHistory: (index: number) => {
     set((state) => ({
       cardsHistory: state.cardsHistory.filter((_, i) => i !== index),
+    }));
+  },
+  toggleFavourite: (index: number) => {
+    set((state) => ({
+      cardsHistory: state.cardsHistory.map((card, i) =>
+        i === index ? { ...card, isFavorited: !card.isFavorited } : card
+      ),
     }));
   },
 });


### PR DESCRIPTION
## What
Added a star icon button to `BingoCard` to allow toggling the favorited state of cards on both the home page and in the history list.

## Why
Users need a way to mark bingo cards as favorites directly from the card view.

## How
- Updated `BingoCard` to accept `title`, `isFavourite`, and `onToggleFavourite` props, incorporating these elements into a new header section within the component.
- Refactored `CardHistoryItem` to leverage the new `BingoCard` props, removing redundant title and button elements from `CardHeader`.
- Extended `CardSlice` in `zustand` to manage `isFavorited` state and added a `toggleCurrentCardFavourite` action for the active card.
- Updated `Home` page to connect the `BingoCard` to the `toggleCurrentCardFavourite` action.
- Fixed a bug in `cardsHistorySlice` where the favorite toggle was referencing the incorrect property name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to mark bingo cards as favorites with a dedicated toggle button.
  * Bingo cards now display titles and persist favorite status for both current and previously saved cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->