### PR TITLE
Update Toggle component and add favorited filter to history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.0.3",
         "@radix-ui/react-toast": "^1.1.5",
-        "@radix-ui/react-toggle": "^1.1.10",
+        "@radix-ui/react-toggle": "^1.1.11",
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.0.7",
         "@tanstack/react-virtual": "^3.13.18",
@@ -3154,14 +3154,14 @@
       }
     },
     "node_modules/@radix-ui/react-toggle": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
-      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.11.tgz",
+      "integrity": "sha512-FikrKJemoBGZQ6uRID0HJqSPBP6D7OppdD2OhLl0ZYLlAyPXI7MezoYGmumwNkrAoRm35xXkb4C8JPfJZZzcaw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3203,6 +3203,145 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.5.tgz",
+      "integrity": "sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.5.tgz",
+      "integrity": "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-toast": "^1.1.5",
-    "@radix-ui/react-toggle": "^1.1.10",
+    "@radix-ui/react-toggle": "^1.1.11",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@tanstack/react-virtual": "^3.13.18",

--- a/src/lib/components/card-history/card-history-list.tsx
+++ b/src/lib/components/card-history/card-history-list.tsx
@@ -1,4 +1,4 @@
-import { BingoCardType } from '@/lib/domain/card/types';
+import { BingoCardType, BingoCardWithIndex } from '@/lib/domain/card/types';
 import VirtualizedList from '../ui/virtualized-list';
 import { useNavigate } from 'react-router-dom';
 import { useBoundStore } from '@/lib/zustand/store';
@@ -7,7 +7,7 @@ import { encodeCardToParams } from '../bingo/generate-button';
 import CardHistoryItem from './card-history-item';
 
 interface CardHistoryListProps {
-  cards: BingoCardType[];
+  cards: BingoCardWithIndex[];
 }
 
 export default function CardHistoryList({ cards }: CardHistoryListProps) {
@@ -30,14 +30,14 @@ export default function CardHistoryList({ cards }: CardHistoryListProps) {
         count={cards.length}
         estimateSize={596}
         renderItem={(index) => {
-          const card = cards[index];
+          const { card, originalIndex } = cards[index];
           return (
             <div className="flex justify-center px-4">
               <CardHistoryItem
                 card={card}
-                index={index}
-                onOpen={() => handleNavigate(index, card)}
-                onDelete={() => removeFromCardsHistory(index)}
+                index={originalIndex}
+                onOpen={() => handleNavigate(originalIndex, card)}
+                onDelete={() => removeFromCardsHistory(originalIndex)}
               />
             </div>
           );

--- a/src/lib/components/ui/toggle.tsx
+++ b/src/lib/components/ui/toggle.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as TogglePrimitive from '@radix-ui/react-toggle';
 import { cva, type VariantProps } from 'class-variance-authority';
-
 import { cn } from '@/lib/styles/utils';
 
+// Original toggleVariants for compatibility
 const toggleVariants = cva(
   'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2',
   {
@@ -28,12 +28,30 @@ const toggleVariants = cva(
 
 const Toggle = React.forwardRef<
   React.ElementRef<typeof TogglePrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
-    VariantProps<typeof toggleVariants>
->(({ className, variant, size, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root>
+>(({ className, ...props }, ref) => (
   <TogglePrimitive.Root
     ref={ref}
-    className={cn(toggleVariants({ variant, size, className }))}
+    className={cn(
+      // 1. BASE BUTTON STYLES (Copied exactly from button.tsx)
+      'translate-3d ring-2 ring-inset after:absolute after:h-full after:w-full after:rounded-md after:bg-primary after:transition-transform active:translate-y-1 style-preserve relative inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+
+      // 2. Icon Sizing
+      'h-10 w-10 p-0',
+
+      // 3. Secondary variant styles (Copied exactly from button.tsx)
+      'bg-secondary text-secondary-foreground ring-stone-300 dark:ring-stone-700 after:bg-stone-200 dark:after:bg-stone-800',
+
+      // 4. ACTIVE/TOGGLED STATE
+      // Move body down
+      'data-[state=on]:translate-y-1',
+      // Change color
+      'data-[state=on]:bg-accent data-[state=on]:text-accent-foreground data-[state=on]:ring-accent',
+      // Hide the shadow (collapse after element height)
+      'data-[state=on]:after:h-0',
+
+      className
+    )}
     {...props}
   />
 ));

--- a/src/lib/domain/card/types.ts
+++ b/src/lib/domain/card/types.ts
@@ -1,5 +1,10 @@
 import { Item } from '../items/types';
 
+export type BingoCardWithIndex = {
+  card: BingoCardType;
+  originalIndex: number;
+};
+
 export type BingoCardType = {
   items: Item[];
   title: string;

--- a/src/lib/pages/card-history/index.tsx
+++ b/src/lib/pages/card-history/index.tsx
@@ -3,7 +3,10 @@ import CardsHistoryEmptyState from '@/lib/components/card-history/cards-history-
 import Header from '@/lib/components/header';
 import GoBackButton from '@/lib/components/ui/go-back-button';
 import { useBoundStore } from '@/lib/zustand/store';
+import { Icon } from '@iconify/react/dist/iconify.js';
+import { useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
+import { Toggle } from '@/lib/components/ui/toggle';
 
 export default function CardHistoryPage() {
   const { cardHistory } = useBoundStore(
@@ -11,14 +14,42 @@ export default function CardHistoryPage() {
       cardHistory: state.cardsHistory,
     }))
   );
+  const [showOnlyFavorited, setShowOnlyFavorited] = useState(false);
+
+  const displayedCards = showOnlyFavorited
+    ? cardHistory.filter((card) => card.isFavorited)
+    : cardHistory;
 
   return (
     <div className="flex h-screen flex-col items-center gap-4">
-      <Header left={<GoBackButton />} title="History" />
-      {cardHistory.length === 0 ? (
-        <CardsHistoryEmptyState />
+      <Header
+        left={<GoBackButton />}
+        title="History"
+        right={
+          <Toggle
+            pressed={showOnlyFavorited}
+            onPressedChange={setShowOnlyFavorited}
+            aria-label="Filter favorited cards"
+          >
+            <Icon
+              className="text-2xl"
+              icon={
+                showOnlyFavorited
+                  ? 'heroicons:bookmark-16-solid'
+                  : 'heroicons:bookmark'
+              }
+            />
+          </Toggle>
+        }
+      />
+      {displayedCards.length === 0 ? (
+        showOnlyFavorited ? (
+          <p className="max-w-xl text-center">No favorited cards found.</p>
+        ) : (
+          <CardsHistoryEmptyState />
+        )
       ) : (
-        <CardHistoryList cards={cardHistory} />
+        <CardHistoryList cards={displayedCards} />
       )}
     </div>
   );

--- a/src/lib/pages/card-history/index.tsx
+++ b/src/lib/pages/card-history/index.tsx
@@ -16,9 +16,14 @@ export default function CardHistoryPage() {
   );
   const [showOnlyFavorited, setShowOnlyFavorited] = useState(false);
 
+  const cardsWithIndex = cardHistory.map((card, index) => ({
+    card,
+    originalIndex: index,
+  }));
+
   const displayedCards = showOnlyFavorited
-    ? cardHistory.filter((card) => card.isFavorited)
-    : cardHistory;
+    ? cardsWithIndex.filter(({ card }) => card.isFavorited)
+    : cardsWithIndex;
 
   return (
     <div className="flex h-screen flex-col items-center gap-4">


### PR DESCRIPTION
## What
Added a bookmark toggle button to the `CardHistoryPage` header to filter and display only favorited cards.

## Why
To provide users with a convenient way to view and manage their favorited bingo cards in the history list.

## How
- Created a new `Toggle` component in `skattjakt\src\lib\components\ui\toggle.tsx` that implements the project's button styling and shadow behavior while supporting persistent active state.
- Updated `skattjakt\src\lib\pages\card-history\index.tsx` to include the `Toggle` for state-driven filtering of the `cardsHistory` list.
- Implemented a fallback empty state message when filtering returns no favorited cards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggle filter to the card history page, allowing you to easily view only your favorited cards with appropriate messaging when no favorites exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->