### PR TITLE
Add rename functionality to BingoCard component

### DIFF
--- a/src/lib/components/bingo/bingo-card.tsx
+++ b/src/lib/components/bingo/bingo-card.tsx
@@ -4,27 +4,30 @@ import { Item } from '@/lib/domain/items/types';
 import { Cell } from '../ui/cell';
 import { Button } from '../ui/button';
 import { Icon } from '@iconify/react/dist/iconify.js';
+import { Input } from '../ui/input';
 
 type BingoCardProps = {
-  disabled?: boolean;
+  disableCells?: boolean;
   items: Item[];
   title?: string;
   isFavourite?: boolean;
   onToggleFavourite?: () => void;
+  onRename?: (title: string) => void;
 };
 
 export const BingoCard = ({
-  disabled,
+  disableCells,
   items,
   title,
   isFavourite,
   onToggleFavourite,
+  onRename,
 }: BingoCardProps) => {
   const [selectedCell, setSelectedCell] = useState<string[]>([]);
+  const [editingTitle, setEditingTitle] = useState<string | null>(null);
 
   const handleCellClick = (cellId: string) => {
-    if (disabled) return;
-
+    if (disableCells) return;
     setSelectedCell((prev) =>
       prev.includes(cellId)
         ? prev.filter((id) => id !== cellId)
@@ -32,26 +35,71 @@ export const BingoCard = ({
     );
   };
 
+  const handleSave = () => {
+    if (editingTitle && editingTitle.trim()) {
+      onRename?.(editingTitle);
+    }
+    setEditingTitle(null);
+  };
+
   return (
     <div className="relative space-y-2 w-full">
-      {(title || onToggleFavourite) && (
-        <div className="flex items-center justify-between">
-          {title && <h3 className="text-lg font-semibold">{title}</h3>}
-          {onToggleFavourite && (
-            <Button
-              variant="secondary"
-              size="icon"
-              onClick={onToggleFavourite}
-              aria-label={isFavourite ? 'Unfavourite card' : 'Favourite card'}
-            >
-              <Icon
-                className="text-2xl"
-                icon={
-                  isFavourite ? 'heroicons:star-16-solid' : 'heroicons:star'
-                }
-              />
-            </Button>
+      {(title || onToggleFavourite || onRename) && (
+        <div className="flex items-center justify-between gap-2 h-10">
+          {editingTitle !== null ? (
+            <Input
+              value={editingTitle}
+              onChange={(e) => setEditingTitle(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleSave();
+                if (e.key === 'Escape') setEditingTitle(null);
+              }}
+              autoFocus
+            />
+          ) : (
+            title && <h3 className="text-lg font-semibold">{title}</h3>
           )}
+
+          <div className="flex items-center gap-2">
+            {onRename && (
+              <Button
+                variant={editingTitle !== null ? 'default' : 'secondary'}
+                size="icon"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (editingTitle !== null) {
+                    handleSave();
+                  } else {
+                    setEditingTitle(title || '');
+                  }
+                }}
+              >
+                <Icon
+                  className="text-2xl"
+                  icon={
+                    editingTitle !== null
+                      ? 'heroicons:check-16-solid'
+                      : 'heroicons:pencil-16-solid'
+                  }
+                />
+              </Button>
+            )}
+            {onToggleFavourite && (
+              <Button
+                variant="secondary"
+                size="icon"
+                onClick={onToggleFavourite}
+                aria-label={isFavourite ? 'Unfavourite card' : 'Favourite card'}
+              >
+                <Icon
+                  className="text-2xl"
+                  icon={
+                    isFavourite ? 'heroicons:star-16-solid' : 'heroicons:star'
+                  }
+                />
+              </Button>
+            )}
+          </div>
         </div>
       )}
       <div className="grid aspect-square w-full grid-cols-5 grid-rows-5 gap-2">
@@ -61,7 +109,7 @@ export const BingoCard = ({
             item={item}
             checked={selectedCell.includes(item.id)}
             onClick={() => handleCellClick(item.id)}
-            disabled={disabled}
+            disabled={disableCells}
           />
         ))}
       </div>

--- a/src/lib/components/bingo/bingo-card.tsx
+++ b/src/lib/components/bingo/bingo-card.tsx
@@ -45,7 +45,9 @@ export const BingoCard = ({
   return (
     <div className="relative space-y-2 w-full">
       {(title || onToggleFavourite || onRename) && (
-        <div className="flex items-center justify-between gap-2 h-10">
+        <div
+          className={`flex items-center ${onRename || onToggleFavourite ? 'justify-between' : 'justify-center'} gap-2 h-10`}
+        >
           {editingTitle !== null ? (
             <Input
               value={editingTitle}

--- a/src/lib/components/bingo/generate-button.tsx
+++ b/src/lib/components/bingo/generate-button.tsx
@@ -8,9 +8,13 @@ import { Button } from '../ui/button';
 import generateCard from '@/lib/domain/card/generateCard';
 import { Item } from '@/lib/domain/items/types';
 
-export function encodeCardToParams(card: Item[]): URLSearchParams {
+export function encodeCardToParams(
+  card: Item[],
+  title: string
+): URLSearchParams {
   const params = new URLSearchParams();
   params.set('c', card.map((item) => item.id).join(','));
+  params.set('t', title);
   return params;
 }
 
@@ -30,12 +34,13 @@ export const GenerateButton = () => {
     const generatedCard = generateCard(
       items.filter((item) => item.isEligible === true)
     );
+    const title = `Card #${cardsHistory.length + 1}`;
     addToCardsHistory({
       items: generatedCard,
-      title: `Card #${cardsHistory.length + 1}`,
+      title,
       isFavorited: false,
     });
-    const link = encodeCardToParams(generatedCard);
+    const link = encodeCardToParams(generatedCard, title);
     setSearchParams(link);
   };
 

--- a/src/lib/components/card-history/card-history-item.tsx
+++ b/src/lib/components/card-history/card-history-item.tsx
@@ -1,17 +1,10 @@
 import { Button } from '../ui/button';
 import { BingoCard } from '../bingo/bingo-card';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  CardFooter,
-} from '../ui/card';
+import { Card, CardContent, CardFooter } from '../ui/card';
 import { BingoCardType } from '@/lib/domain/card/types';
 import ConfirmationDialog from '../blocks/confirmation-dialog';
 import { useBoundStore } from '@/lib/zustand/store';
 import { useShallow } from 'zustand/react/shallow';
-import { Icon } from '@iconify/react';
 
 interface CardHistoryItemProps {
   card: BingoCardType;
@@ -26,20 +19,22 @@ export default function CardHistoryItem({
   onDelete,
   index,
 }: CardHistoryItemProps) {
-  const { toggleFavourite } = useBoundStore(
+  const { toggleFavourite, renameCard } = useBoundStore(
     useShallow((state) => ({
       toggleFavourite: state.toggleFavourite,
+      renameCard: state.renameCard,
     }))
   );
   return (
     <Card className="w-fit">
       <CardContent>
         <BingoCard
-          disabled
+          disableCells
           title={card.title}
           items={card.items}
           isFavourite={card.isFavorited}
           onToggleFavourite={() => toggleFavourite(index)}
+          onRename={(newTitle) => renameCard(index, newTitle)}
         />
       </CardContent>
       <CardFooter className="gap-2">

--- a/src/lib/components/card-history/card-history-list.tsx
+++ b/src/lib/components/card-history/card-history-list.tsx
@@ -20,7 +20,7 @@ export default function CardHistoryList({ cards }: CardHistoryListProps) {
   const navigate = useNavigate();
   const handleNavigate = (index: number, card: BingoCardType) => {
     openCard(index);
-    const params = encodeCardToParams(card.items);
+    const params = encodeCardToParams(card.items, card.title);
     navigate(`../?${params}`);
   };
 

--- a/src/lib/components/footer.tsx
+++ b/src/lib/components/footer.tsx
@@ -7,15 +7,16 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from './ui/tooltip';
-import { ModeToggle } from './ui/mode-toggle';
 import UserPreferencesButton from './user-preferences/user-preferences-button';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
 const version = APP_VERSION;
-export const Footer = () => {
+export const Footer = ({ hideControls }: { hideControls?: boolean }) => {
   return (
-    <footer className="flex max-h-24 w-full items-center justify-between grow gap-1 bg-background px-4">
+    <footer
+      className={`flex h-24 w-full items-center ${hideControls ? 'justify-center' : 'justify-between'} bg-background px-4`}
+    >
       <div className="flex">
         <p>Made with</p>
         <TooltipProvider>
@@ -57,7 +58,7 @@ export const Footer = () => {
           </Tooltip>
         </TooltipProvider>
       </div>
-      <UserPreferencesButton />
+      {!hideControls && <UserPreferencesButton />}
     </footer>
   );
 };

--- a/src/lib/components/share-button.tsx
+++ b/src/lib/components/share-button.tsx
@@ -26,9 +26,9 @@ export const ShareButton = () => {
   useEffect(() => {
     const url = new URL(pageUrl);
     if (showControls) {
-      url.searchParams.delete('show-controls');
+      url.searchParams.set('show-controls', '');
     } else {
-      url.searchParams.set('show-controls', 'false');
+      url.searchParams.delete('show-controls');
     }
     setShareUrl(url.toString());
   }, [showControls, pageUrl]);

--- a/src/lib/components/share-button.tsx
+++ b/src/lib/components/share-button.tsx
@@ -26,9 +26,9 @@ export const ShareButton = () => {
   useEffect(() => {
     const url = new URL(pageUrl);
     if (showControls) {
-      url.searchParams.set('show-controls', '');
+      url.searchParams.delete('hide-controls');
     } else {
-      url.searchParams.delete('show-controls');
+      url.searchParams.set('hide-controls', '');
     }
     setShareUrl(url.toString());
   }, [showControls, pageUrl]);

--- a/src/lib/components/share-button.tsx
+++ b/src/lib/components/share-button.tsx
@@ -24,16 +24,14 @@ export const ShareButton = () => {
   const { toast } = useToast();
 
   useEffect(() => {
-    const updateShareUrl = (controlsHidden: boolean) => {
-      setShareUrl(`${pageUrl}${controlsHidden ? '' : '&show-controls'}`);
-    };
-
-    updateShareUrl(showControls);
+    const url = new URL(pageUrl);
+    if (showControls) {
+      url.searchParams.delete('show-controls');
+    } else {
+      url.searchParams.set('show-controls', 'false');
+    }
+    setShareUrl(url.toString());
   }, [showControls, pageUrl]);
-
-  const handleControlsChange = () => {
-    setShowControls((prevShowControls) => !prevShowControls);
-  };
 
   const handleCopyClick = () => {
     navigator.clipboard.writeText(shareUrl);
@@ -61,7 +59,7 @@ export const ShareButton = () => {
               <Label htmlFor="show-controls">Show controls</Label>
               <Switch
                 id="show-controls"
-                onCheckedChange={handleControlsChange}
+                onCheckedChange={setShowControls}
                 checked={showControls}
               />
             </div>

--- a/src/lib/pages/home/index.tsx
+++ b/src/lib/pages/home/index.tsx
@@ -18,7 +18,7 @@ import UserPreferencesButton from '@/lib/components/user-preferences/user-prefer
 
 export default function Home() {
   const [searchParams] = useSearchParams();
-  const hideControls = !searchParams.has('show-controls');
+  const hideControls = searchParams.has('hide-controls');
   const {
     items,
     cardsHistory,

--- a/src/lib/pages/home/index.tsx
+++ b/src/lib/pages/home/index.tsx
@@ -14,6 +14,7 @@ import { BINGO_GRID_SIZE } from '@/lib/domain/card/generateCard';
 import { useEffect } from 'react';
 import { Item } from '@/lib/domain/items/types';
 import IconLink from '@/lib/components/ui/icon-link';
+import UserPreferencesButton from '@/lib/components/user-preferences/user-preferences-button';
 
 export default function Home() {
   const [searchParams] = useSearchParams();
@@ -71,7 +72,9 @@ export default function Home() {
         left={<AppLogo />}
         title="Skattjakt"
         right={
-          !hideControls && (
+          hideControls ? (
+            <UserPreferencesButton />
+          ) : (
             <IconLink
               to="/cards-history"
               icon="heroicons-rectangle-stack-16-solid"
@@ -102,7 +105,7 @@ export default function Home() {
           </div>
         )}
       </div>
-      <Footer />
+      <Footer hideControls={hideControls} />
     </div>
   );
 }

--- a/src/lib/pages/home/index.tsx
+++ b/src/lib/pages/home/index.tsx
@@ -17,16 +17,23 @@ import IconLink from '@/lib/components/ui/icon-link';
 
 export default function Home() {
   const [searchParams] = useSearchParams();
-  const hideControls = searchParams.get('show-controls') !== null;
-  const { items, cardsHistory, addToCardsHistory, toggleFavourite } =
-    useBoundStore(
-      useShallow((state) => ({
-        items: state.items,
-        cardsHistory: state.cardsHistory,
-        addToCardsHistory: state.addToCardsHistory,
-        toggleFavourite: state.toggleFavourite,
-      }))
-    );
+  const showControlsParam = searchParams.get('show-controls');
+  const hideControls = showControlsParam === 'false';
+  const {
+    items,
+    cardsHistory,
+    addToCardsHistory,
+    toggleFavourite,
+    renameCard,
+  } = useBoundStore(
+    useShallow((state) => ({
+      items: state.items,
+      cardsHistory: state.cardsHistory,
+      addToCardsHistory: state.addToCardsHistory,
+      toggleFavourite: state.toggleFavourite,
+      renameCard: state.renameCard,
+    }))
+  );
 
   const activeCard = cardsHistory[0];
 
@@ -46,9 +53,10 @@ export default function Home() {
       .filter((item): item is Item => item !== undefined);
 
     if (newCard.length === BINGO_GRID_SIZE) {
+      const title = searchParams.get('t') ?? 'Shared Card';
       addToCardsHistory({
         items: newCard,
-        title: `Shared Card`,
+        title,
         isFavorited: false,
       });
     }
@@ -63,18 +71,25 @@ export default function Home() {
         left={<AppLogo />}
         title="Skattjakt"
         right={
-          <IconLink
-            to="/cards-history"
-            icon="heroicons-rectangle-stack-16-solid"
-          />
+          !hideControls && (
+            <IconLink
+              to="/cards-history"
+              icon="heroicons-rectangle-stack-16-solid"
+            />
+          )
         }
       />
       <div className="z-0 flex h-full w-full max-w-xl  flex-1 flex-col items-center justify-center gap-6 px-4">
         <BingoCard
-          title="Bingo Card Generator"
+          title={activeCard?.title ?? 'Bingo Card Generator'}
           items={activeCard?.items ?? []}
           isFavourite={activeCard?.isFavorited ?? false}
-          onToggleFavourite={() => toggleFavourite(0)}
+          onToggleFavourite={
+            !hideControls ? () => toggleFavourite(0) : undefined
+          }
+          onRename={
+            !hideControls ? (newTitle) => renameCard(0, newTitle) : undefined
+          }
         />
         {!hideControls && (
           <div className="flex w-full flex-row items-center justify-end gap-2">

--- a/src/lib/pages/home/index.tsx
+++ b/src/lib/pages/home/index.tsx
@@ -18,8 +18,7 @@ import UserPreferencesButton from '@/lib/components/user-preferences/user-prefer
 
 export default function Home() {
   const [searchParams] = useSearchParams();
-  const showControlsParam = searchParams.get('show-controls');
-  const hideControls = showControlsParam === 'false';
+  const hideControls = !searchParams.has('show-controls');
   const {
     items,
     cardsHistory,

--- a/src/lib/zustand/cardsHistorySlice.ts
+++ b/src/lib/zustand/cardsHistorySlice.ts
@@ -6,6 +6,7 @@ export type CardsHistorySlice = {
   addToCardsHistory: (card: BingoCardType) => void;
   removeFromCardsHistory: (index: number) => void;
   toggleFavourite: (index: number) => void;
+  renameCard: (index: number, title: string) => void;
   openCard: (index: number) => void;
 };
 
@@ -26,6 +27,13 @@ export const createCardHistorySlice: StateCreator<CardsHistorySlice> = (
     set((state) => ({
       cardsHistory: state.cardsHistory.map((card, i) =>
         i === index ? { ...card, isFavorited: !card.isFavorited } : card
+      ),
+    }));
+  },
+  renameCard: (index: number, title: string) => {
+    set((state) => ({
+      cardsHistory: state.cardsHistory.map((card, i) =>
+        i === index ? { ...card, title } : card
       ),
     }));
   },


### PR DESCRIPTION
## What
Adds card title to share URLs, fixes controls param naming, wires up inline card renaming across homepage and history, and fixes several bugs introduced during implementation.

## Why
Share links lost the card title, the `show-controls` param logic was inverted causing confusing behavior, and cards had no way to be renamed after generation.

## How
- `encodeCardToParams` now accepts a `title` argument and encodes it as a `t` param; all callers (`generate-button.tsx`, `card-history-list.tsx`) updated to pass the card title
- `show-controls` param semantics corrected — presence of param now means controls are visible; `hideControls` derivation in `home/index.tsx` updated accordingly; `ShareButton` label and default state updated to match
- `renameCard(index, title)` action added to `cardsHistorySlice`; `BingoCard` accepts `onRename` prop and manages edit state via a single `editingTitle: string | null` value — `null` = view mode, string = edit mode
- `onToggleFavourite` and `onRename` passed as `undefined` when controls are hidden rather than encoding visibility into `isFavourite` state
- `disabled` removed from `BingoCard` in `card-history-item.tsx` to allow title editing in history view
- Shared card loaded from URL uses `t` param as title, falling back to `"Shared Card"` if absent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now rename cards in their history for better organization.
  * Card titles are now preserved and included when sharing cards via URL.
  * Improved control over cell interactivity during gameplay.

* **Improvements**
  * Enhanced share controls and visibility management for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->