### PR TITLE
Add preferences slice to store

### DIFF
--- a/src/lib/zustand/preferencesSlice.ts
+++ b/src/lib/zustand/preferencesSlice.ts
@@ -1,0 +1,16 @@
+import { StateCreator } from 'zustand';
+
+export interface PreferencesSlice {
+  raritySlots: {
+    rare: number;
+    epic: number;
+  };
+  setRaritySlots: (slots: { rare: number; epic: number }) => void;
+}
+
+export const createPreferencesSlice: StateCreator<PreferencesSlice> = (
+  set
+) => ({
+  raritySlots: { rare: 4, epic: 1 },
+  setRaritySlots: (slots) => set({ raritySlots: slots }),
+});

--- a/src/lib/zustand/store.ts
+++ b/src/lib/zustand/store.ts
@@ -3,20 +3,23 @@ import { persist } from 'zustand/middleware';
 import { createItemsSlice } from './itemsSlice';
 import { ItemsSlice } from '../domain/items/types';
 import { CardsHistorySlice, createCardHistorySlice } from './cardsHistorySlice';
+import { PreferencesSlice, createPreferencesSlice } from './preferencesSlice';
 
-export type BoundStore = ItemsSlice & CardsHistorySlice;
+export type BoundStore = ItemsSlice & CardsHistorySlice & PreferencesSlice;
 
 export const useBoundStore = create<BoundStore>()(
   persist(
     (...a) => ({
       ...createItemsSlice(...a),
       ...createCardHistorySlice(...a),
+      ...createPreferencesSlice(...a),
     }),
     {
       name: 'skattjakt-storage',
       partialize: (state) => ({
         items: state.items,
         cardsHistory: state.cardsHistory,
+        raritySlots: state.raritySlots,
       }),
     }
   )


### PR DESCRIPTION
## What
Implemented a `preferencesSlice` in Zustand to manage `raritySlots` and ensured its persistence in `skattjakt-storage`.

## Why
This is required to allow configuration of rarity slots that persist across user sessions.

## How
- Created `src/lib/zustand/preferencesSlice.ts` defining the `raritySlots` state and `setRaritySlots` action.
- Updated `src/lib/zustand/store.ts` to add `PreferencesSlice` to the `BoundStore` type.
- Modified the `persist` middleware in `src/lib/zustand/store.ts` to include `raritySlots` in the persisted state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preference management system for configurable rarity slots, enabling users to customize rare and epic item settings.
  * User preferences are now automatically persisted and restored across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->