### PR TITLE
Implement rarity-based card generation and update item pool filtering

### DIFF
--- a/src/lib/components/bingo/generate-button.tsx
+++ b/src/lib/components/bingo/generate-button.tsx
@@ -19,11 +19,12 @@ export function encodeCardToParams(
 }
 
 export const GenerateButton = () => {
-  const { items, addToCardsHistory, cardsHistory } = useBoundStore(
+  const { items, addToCardsHistory, cardsHistory, raritySlots } = useBoundStore(
     useShallow((state) => ({
       items: state.items,
       addToCardsHistory: state.addToCardsHistory,
       cardsHistory: state.cardsHistory,
+      raritySlots: state.raritySlots,
     }))
   );
   const [spinning, setSpinning] = useState(false);
@@ -32,7 +33,8 @@ export const GenerateButton = () => {
   const handleGenerateAndSetCard = () => {
     setSpinning(true);
     const generatedCard = generateCard(
-      items.filter((item) => item.isEligible === true)
+      items.filter((item) => item.isEligible === true),
+      raritySlots
     );
     const title = `Card #${cardsHistory.length + 1}`;
     addToCardsHistory({

--- a/src/lib/domain/card/generateCard.ts
+++ b/src/lib/domain/card/generateCard.ts
@@ -1,10 +1,44 @@
 import type { Item } from '../items/types';
+import type { PreferencesSlice } from '@/lib/zustand/preferencesSlice';
 
 export const BINGO_GRID_SIZE = 25;
 
-export default function generateCard(items: Item[]): Item[] {
-  return items
-    .slice()
-    .sort(() => Math.random() - 0.5)
-    .slice(0, BINGO_GRID_SIZE);
+export default function generateCard(
+  items: Item[],
+  raritySlots: PreferencesSlice['raritySlots']
+): Item[] {
+  const eligibleItems = items.filter((item) => item.isEligible);
+
+  const epicPool = eligibleItems
+    .filter((i) => i.rarity === 'epic')
+    .sort(() => Math.random() - 0.5);
+  const rarePool = eligibleItems
+    .filter((i) => i.rarity === 'rare')
+    .sort(() => Math.random() - 0.5);
+  const commonPool = eligibleItems
+    .filter((i) => i.rarity !== 'epic' && i.rarity !== 'rare')
+    .sort(() => Math.random() - 0.5);
+
+  const selectedItems: Item[] = [];
+
+  const targetEpic = Math.max(0, Math.min(raritySlots.epic, BINGO_GRID_SIZE));
+  const targetRare = Math.max(
+    0,
+    Math.min(raritySlots.rare, BINGO_GRID_SIZE - targetEpic)
+  );
+  const targetCommon = BINGO_GRID_SIZE - targetEpic - targetRare;
+
+  const fillTier = (pool: Item[], count: number) => {
+    const taken = pool.splice(0, count);
+    selectedItems.push(...taken);
+    return count - taken.length;
+  };
+
+  let remainingSlots = fillTier(epicPool, targetEpic);
+  remainingSlots = fillTier(rarePool, targetRare + remainingSlots);
+  fillTier(commonPool, targetCommon + remainingSlots);
+
+  return selectedItems
+    .slice(0, BINGO_GRID_SIZE)
+    .sort(() => Math.random() - 0.5);
 }

--- a/src/lib/domain/card/generateCard.ts
+++ b/src/lib/domain/card/generateCard.ts
@@ -16,7 +16,7 @@ export default function generateCard(
     .filter((i) => i.rarity === 'rare')
     .sort(() => Math.random() - 0.5);
   const commonPool = eligibleItems
-    .filter((i) => i.rarity !== 'epic' && i.rarity !== 'rare')
+    .filter((i) => i.rarity === 'common')
     .sort(() => Math.random() - 0.5);
 
   const selectedItems: Item[] = [];


### PR DESCRIPTION
## What
Refactored `generateCard` to use explicit rarity categorization and added slot-based generation logic.

## Why
To enable configurable rarity distribution on bingo cards while ensuring strictly bounded grid capacity and consistent data handling.

## How
- Updated `generateCard` in `src/lib/domain/card/generateCard.ts` to use explicit `'common'` rarity filtering and added defensive slot clamping to strictly guarantee a maximum of 25 items.
- Integrated `raritySlots` from `preferencesSlice` into `GenerateButton` in `src/lib/components/bingo/generate-button.tsx` to drive the generation process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bingo card generation now intelligently balances item rarity distribution based on your preferences, ensuring epic, rare, and common items are included according to your configured settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->