### PR TITLE
Add setRarity action to items slice

### DIFF
--- a/src/lib/domain/items/types.ts
+++ b/src/lib/domain/items/types.ts
@@ -14,4 +14,5 @@ export type ItemsSlice = {
   resetItems: () => void;
   addItem: (item: NewItem) => void;
   setEligibilityByIds: (ids: string[], value: boolean) => void;
+  setRarity: (id: string, rarity: Item['rarity']) => void;
 };

--- a/src/lib/zustand/itemsSlice.ts
+++ b/src/lib/zustand/itemsSlice.ts
@@ -37,4 +37,10 @@ export const createItemsSlice: StateCreator<ItemsSlice> = (set, get) => ({
     if (!item) return;
     get().setEligibilityByIds([id], !item?.isEligible);
   },
+  setRarity: (id: string, rarity: Item['rarity']) => {
+    const next = get().items.map((item) =>
+      item.id === id ? { ...item, rarity } : item
+    );
+    set({ items: next });
+  },
 });


### PR DESCRIPTION
## What
Added a `setRarity(id, rarity)` action to the `itemsSlice` to allow updating an item's rarity.

## Why
This action is required to enable functionality for modifying the rarity of items within the application state.

## How
- Added the `setRarity` function signature to the `ItemsSlice` type in `src/lib/domain/items/types.ts`.
- Implemented `setRarity` in `src/lib/zustand/itemsSlice.ts`, using `map` to immutably update the `rarity` field for the item matching the provided `id`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to update item rarity values, enabling dynamic modification of item properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->