### PR TITLE
Add rarity selector to item list

### DIFF
--- a/src/lib/components/items/filter-items.tsx
+++ b/src/lib/components/items/filter-items.tsx
@@ -27,6 +27,7 @@ export default function FilterItems() {
       defaultValue="all"
     >
       <ToggleGroupItem
+        className="whitespace-nowrap p-2"
         value="all"
         key={'all'}
         onClick={() => handleCategoryCLick(null)}
@@ -36,7 +37,7 @@ export default function FilterItems() {
       {categories.map((category) => {
         return (
           <ToggleGroupItem
-            className="whitespace-nowrap"
+            className="whitespace-nowrap p-2"
             onClick={() => handleCategoryCLick(category)}
             value={category}
             key={category}

--- a/src/lib/components/items/filter-items.tsx
+++ b/src/lib/components/items/filter-items.tsx
@@ -22,11 +22,9 @@ export default function FilterItems() {
 
   return (
     <ToggleGroup
-      className="justify-start"
+      className="justify-start py-1"
       type="single"
-      size="sm"
       defaultValue="all"
-      variant="outline"
     >
       <ToggleGroupItem
         value="all"

--- a/src/lib/components/items/items-list.tsx
+++ b/src/lib/components/items/items-list.tsx
@@ -10,9 +10,6 @@ import { Item as ItemType } from '@/lib/domain/items/types';
 import VirtualizedList from '../ui/virtualized-list';
 import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
 
-const pressAnimationClasses =
-  'translate-3d ring-2 ring-inset after:absolute after:h-full after:w-full after:rounded-md after:bg-primary after:transition-transform active:translate-y-1 relative data-[state=on]:translate-y-1 data-[state=on]:after:h-0';
-
 interface ItemsListProps {
   items: ItemType[];
   toggleEligibility: (id: string) => void;

--- a/src/lib/components/items/items-list.tsx
+++ b/src/lib/components/items/items-list.tsx
@@ -8,15 +8,21 @@ import {
 import { Switch } from '../ui/switch';
 import { Item as ItemType } from '@/lib/domain/items/types';
 import VirtualizedList from '../ui/virtualized-list';
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
+
+const pressAnimationClasses =
+  'translate-3d ring-2 ring-inset after:absolute after:h-full after:w-full after:rounded-md after:bg-primary after:transition-transform active:translate-y-1 relative data-[state=on]:translate-y-1 data-[state=on]:after:h-0';
 
 interface ItemsListProps {
   items: ItemType[];
   toggleEligibility: (id: string) => void;
+  setRarity: (id: string, rarity: ItemType['rarity']) => void;
 }
 
 export default function ItemsList({
   items,
   toggleEligibility,
+  setRarity,
 }: ItemsListProps) {
   return (
     <VirtualizedList
@@ -34,9 +40,41 @@ export default function ItemsList({
               <img src={`./items/${item.id}.png`} alt={item.name} />
             </ItemMedia>
             <ItemContent>
-              <ItemTitle>{item.name}</ItemTitle>
+              <ItemTitle className="flex-1 min-w-0 truncate">
+                {item.name}
+              </ItemTitle>
             </ItemContent>
             <ItemActions>
+              <ToggleGroup
+                type="single"
+                value={item.rarity}
+                onValueChange={(value) =>
+                  value && setRarity(item.id, value as ItemType['rarity'])
+                }
+              >
+                <ToggleGroupItem
+                  value="common"
+                  aria-label="Common"
+                  className="w-9 h-9 p-0"
+                >
+                  C
+                </ToggleGroupItem>
+                <ToggleGroupItem
+                  value="rare"
+                  aria-label="Rare"
+                  className="w-9 h-9 p-0"
+                >
+                  R
+                </ToggleGroupItem>
+                <ToggleGroupItem
+                  value="epic"
+                  aria-label="Epic"
+                  className="w-9 h-9 p-0"
+                >
+                  E
+                </ToggleGroupItem>
+              </ToggleGroup>
+
               <Switch
                 onCheckedChange={() => toggleEligibility(item.id)}
                 checked={item.isEligible}

--- a/src/lib/components/ui/item.tsx
+++ b/src/lib/components/ui/item.tsx
@@ -10,7 +10,10 @@ function ItemGroup({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       role="list"
       data-slot="item-group"
-      className={cn('group/item-group flex flex-col', className)}
+      className={cn(
+        'flex flex-1 flex-col gap-1 min-w-0 [&+[data-slot=item-content]]:flex-none',
+        className
+      )}
       {...props}
     />
   );

--- a/src/lib/components/ui/toggle-group.tsx
+++ b/src/lib/components/ui/toggle-group.tsx
@@ -2,59 +2,44 @@
 
 import * as React from 'react';
 import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
-import { type VariantProps } from 'class-variance-authority';
-
 import { cn } from '@/lib/styles/utils';
-import { toggleVariants } from '@/lib/components/ui/toggle';
 
-const ToggleGroupContext = React.createContext<
-  VariantProps<typeof toggleVariants>
->({
-  size: 'default',
-  variant: 'default',
-});
+const baseToggleClasses = cn(
+  'translate-3d ring-2 ring-inset after:absolute after:h-full after:w-full after:rounded-md after:bg-primary after:transition-transform active:translate-y-1 style-preserve relative inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+  'p-2',
+  'bg-secondary text-secondary-foreground ring-stone-300 dark:ring-stone-700 after:bg-stone-200 dark:after:bg-stone-800',
+  'data-[state=on]:translate-y-1 data-[state=on]:after:h-0 data-[state=on]:bg-secondary',
+  'data-[state=on]:translate-y-1',
+  'data-[state=on]:bg-accent data-[state=on]:text-accent-foreground data-[state=on]:ring-accent',
+  'data-[state=on]:after:h-0'
+);
 
 const ToggleGroup = React.forwardRef<
   React.ElementRef<typeof ToggleGroupPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
-    VariantProps<typeof toggleVariants>
->(({ className, variant, size, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root>
+>(({ className, ...props }, ref) => (
   <ToggleGroupPrimitive.Root
     ref={ref}
-    className={cn('flex items-center justify-center gap-1', className)}
+    className={cn(
+      'flex items-center justify-start gap-1 flex-shrink-0',
+      className
+    )}
     {...props}
-  >
-    <ToggleGroupContext.Provider value={{ variant, size }}>
-      {children}
-    </ToggleGroupContext.Provider>
-  </ToggleGroupPrimitive.Root>
+  />
 ));
 
 ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
 
 const ToggleGroupItem = React.forwardRef<
   React.ElementRef<typeof ToggleGroupPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
-    VariantProps<typeof toggleVariants>
->(({ className, children, variant, size, ...props }, ref) => {
-  const context = React.useContext(ToggleGroupContext);
-
-  return (
-    <ToggleGroupPrimitive.Item
-      ref={ref}
-      className={cn(
-        toggleVariants({
-          variant: context.variant || variant,
-          size: context.size || size,
-        }),
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </ToggleGroupPrimitive.Item>
-  );
-});
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <ToggleGroupPrimitive.Item
+    ref={ref}
+    className={cn(baseToggleClasses, className)}
+    {...props}
+  />
+));
 
 ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName;
 

--- a/src/lib/components/ui/toggle-group.tsx
+++ b/src/lib/components/ui/toggle-group.tsx
@@ -6,12 +6,8 @@ import { cn } from '@/lib/styles/utils';
 
 const baseToggleClasses = cn(
   'translate-3d ring-2 ring-inset after:absolute after:h-full after:w-full after:rounded-md after:bg-primary after:transition-transform active:translate-y-1 style-preserve relative inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
-  'p-2',
   'bg-secondary text-secondary-foreground ring-stone-300 dark:ring-stone-700 after:bg-stone-200 dark:after:bg-stone-800',
-  'data-[state=on]:translate-y-1 data-[state=on]:after:h-0 data-[state=on]:bg-secondary',
-  'data-[state=on]:translate-y-1',
-  'data-[state=on]:bg-accent data-[state=on]:text-accent-foreground data-[state=on]:ring-accent',
-  'data-[state=on]:after:h-0'
+  'data-[state=on]:translate-y-1 data-[state=on]:after:h-0 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground data-[state=on]:ring-accent'
 );
 
 const ToggleGroup = React.forwardRef<

--- a/src/lib/pages/items/index.tsx
+++ b/src/lib/pages/items/index.tsx
@@ -11,7 +11,7 @@ import { useQueryState } from 'nuqs';
 export default function ItemsPage() {
   const [category] = useQueryState('category');
   const [query] = useQueryState('query');
-  const { items, toggleEligibility } = useBoundStore();
+  const { items, toggleEligibility, setRarity } = useBoundStore();
   const searchedItems = useSearchedItems(items, query);
   const filteredItems = useFilteredItems(searchedItems, category);
 
@@ -23,7 +23,11 @@ export default function ItemsPage() {
         right={<ResetItemsButton />}
       />
       <ItemsControl items={filteredItems} />
-      <ItemsList items={filteredItems} toggleEligibility={toggleEligibility} />
+      <ItemsList
+        items={filteredItems}
+        toggleEligibility={toggleEligibility}
+        setRarity={setRarity}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## What
Added a 3-button rarity toggle (C/R/E) to `ItemActions` in `items-list.tsx` to allow updating item rarity directly.

## Why
Users need to efficiently assign rarity ('common', 'rare', 'epic') to items without navigating to a separate edit page.

## How
- Updated `ItemsList` and `ItemsListProps` in `items-list.tsx` to handle `setRarity` and render the new `ToggleGroup`.
- Refactored `ToggleGroupItem` in `ui/toggle-group.tsx` to inherit base `Toggle` component styles and animations for a consistent active state.
- Applied specific sizing (`w-9 h-9`) to rarity toggles in `items-list.tsx` to ensure a static, compact layout.
- Added `relative` positioning to `filter-items.tsx` to fix layout issues caused by shared `ToggleGroup` styles.
- Updated `ItemTitle` in `items-list.tsx` with truncation to prevent layout overflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Items can now be assigned rarity classifications (common, rare, epic) through dedicated selection controls in the item list

* **Improvements**
  * Refined category filter styling for better visual spacing and layout
  * Enhanced item list display with improved text truncation and overall visual organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->