### PR TITLE
Add rarity-based ring colors to cell component

### DIFF
--- a/src/lib/components/ui/cell.tsx
+++ b/src/lib/components/ui/cell.tsx
@@ -8,6 +8,12 @@ type CellProps = {
   disabled?: boolean;
 };
 
+const rarityRingColors: Record<Item['rarity'], string> = {
+  common: 'ring-stone-300 dark:ring-stone-700',
+  rare: 'ring-[#BA7517] dark:ring-[#BA7517]',
+  epic: 'ring-[#534AB7] dark:ring-[#534AB7]',
+};
+
 export const Cell = ({ item, checked, onClick, disabled }: CellProps) => {
   const { id, name } = item;
 
@@ -27,7 +33,7 @@ export const Cell = ({ item, checked, onClick, disabled }: CellProps) => {
       } style-preserve translate-3d flex items-center justify-center break-words transition-all active:translate-y-1`}
     >
       <div
-        className={`h-full w-full rounded-2xl bg-card p-3 ${checked ? 'opacity-30' : ''} ${disabled ? '' : 'ring-2 ring-inset ring-stone-300 dark:ring-stone-700'}`}
+        className={`h-full w-full rounded-2xl bg-card p-3 ${checked ? 'opacity-30' : ''} ${disabled ? '' : `ring-2 ring-inset ${rarityRingColors[item.rarity]}`}`}
       >
         <img
           src={`./items/${id}.png`}


### PR DESCRIPTION
## What
Added rarity-based colored rings to the `Cell` component.

## Why
To visually distinguish items by rarity (Common, Rare, Epic) in the bingo grid.

## How
- Defined a `rarityRingColors` mapping in `src/lib/components/ui/cell.tsx` to associate rarities with specific Tailwind ring classes.
- Updated the `Cell` component to dynamically apply the appropriate class based on the `item.rarity` prop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual distinction for item rarities with dynamic ring styling that now corresponds to each item's rarity level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->