### PR TITLE
Enhance difficulty dialog state management and advanced mode

### DIFF
--- a/src/lib/components/user-preferences/difficulty-dialog.tsx
+++ b/src/lib/components/user-preferences/difficulty-dialog.tsx
@@ -21,18 +21,18 @@ const PRESETS = [
 
 export function DifficultyDialog() {
   const { raritySlots, setRaritySlots } = useBoundStore();
-  const [isAdvanced, setIsAdvanced] = useState(false);
-
   const currentPresetIndex = PRESETS.findIndex(
     (p) => p.rare === raritySlots.rare && p.epic === raritySlots.epic
   );
 
+  const [isAdvanced, setIsAdvanced] = useState(currentPresetIndex === -1);
+
   useEffect(() => {
-    if (currentPresetIndex === -1) {
+    if (!isAdvanced && currentPresetIndex === -1) {
       setSliderValue(1);
       setRaritySlots(PRESETS[1]);
     }
-  }, [currentPresetIndex, setRaritySlots]);
+  }, [isAdvanced, currentPresetIndex, setRaritySlots]);
 
   const [sliderValue, setSliderValue] = useState(
     currentPresetIndex === -1 ? 1 : currentPresetIndex


### PR DESCRIPTION
## What
Updated the `DifficultyDialog` component to improve state persistence for custom rarity configurations.

## Why
Custom rarity settings in Advanced mode were being incorrectly reset to preset values upon component mount or mode switching.

## How
*   Initialized `isAdvanced` state by checking if `raritySlots` match an existing preset to ensure proper mode detection on mount.
*   Updated the `useEffect` hook to only reset `raritySlots` to the default preset when in Simple mode, preserving custom values in Advanced mode.
*   Added `isAdvanced` to the `useEffect` dependency array.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed difficulty dialog preset behavior when switching between simple and advanced modes to prevent unnecessary resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->