### PR TITLE
Release 2.2.0. Add rarity field to items and implement related UI and logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-separator": "^1.1.8",
+        "@radix-ui/react-slider": "^1.4.0",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.0.3",
         "@radix-ui/react-toast": "^1.1.5",
@@ -3068,6 +3069,248 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.0.tgz",
+      "integrity": "sha512-RHcPlLOThRJM51DSIC33ZnpDEBYhyEFroVWkd2P54PGGjkmAt14RboYUU9E1MFst666zFHM0tGtWvMjSOtU1pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.2",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/number": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.2.tgz",
+      "integrity": "sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.9.tgz",
+      "integrity": "sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-context": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.5.tgz",
+      "integrity": "sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.5.tgz",
+      "integrity": "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz",
+      "integrity": "sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+      "integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skattjakt",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "private": false,
   "author": "imdarkly",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-separator": "^1.1.8",
+    "@radix-ui/react-slider": "^1.4.0",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-toast": "^1.1.5",

--- a/src/lib/api/items.json
+++ b/src/lib/api/items.json
@@ -3,7428 +3,8666 @@
     "id": "acacia_boat",
     "name": "Acacia Boat",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_button",
     "name": "Acacia Button",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_chest_boat",
     "name": "Acacia Chest Boat",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_door",
     "name": "Acacia Door",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_fence",
     "name": "Acacia Fence",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_fence_gate",
     "name": "Acacia Fence Gate",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_hanging_sign",
     "name": "Acacia Hanging Sign",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_leaves",
     "name": "Acacia Leaves",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_log",
     "name": "Acacia Log",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_planks",
     "name": "Acacia Planks",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_pressure_plate",
     "name": "Acacia Pressure Plate",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_sapling",
     "name": "Acacia Sapling",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_sign",
     "name": "Acacia Sign",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_slab",
     "name": "Acacia Slab",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_stairs",
     "name": "Acacia Stairs",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_trapdoor",
     "name": "Acacia Trapdoor",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "acacia_wood",
     "name": "Acacia Wood",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "activator_rail",
     "name": "Activator Rail",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "air",
     "name": "Air",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "allay_spawn_egg",
     "name": "Allay Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "allium",
     "name": "Allium",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "amethyst_block",
     "name": "Amethyst Block",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "amethyst_cluster",
     "name": "Amethyst Cluster",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "amethyst_shard",
     "name": "Amethyst Shard",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "ancient_debris",
     "name": "Ancient Debris",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "andesite",
     "name": "Andesite",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "andesite_slab",
     "name": "Andesite Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "andesite_stairs",
     "name": "Andesite Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "andesite_wall",
     "name": "Andesite Wall",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "angler_pottery_sherd",
     "name": "Angler Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "anvil",
     "name": "Anvil",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "apple",
     "name": "Apple",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "archer_pottery_sherd",
     "name": "Archer Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "armor_stand",
     "name": "Armor Stand",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "arms_up_pottery_sherd",
     "name": "Arms Up Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "arrow",
     "name": "Arrow",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "axolotl_bucket",
     "name": "Axolotl Bucket",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "axolotl_spawn_egg",
     "name": "Axolotl Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "azalea",
     "name": "Azalea",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "azalea_leaves",
     "name": "Azalea Leaves",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "azure_bluet",
     "name": "Azure Bluet",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "baked_potato",
     "name": "Baked Potato",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "bamboo",
     "name": "Bamboo",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_block",
     "name": "Bamboo Block",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_button",
     "name": "Bamboo Button",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_chest_raft",
     "name": "Bamboo Chest Raft",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_door",
     "name": "Bamboo Door",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_fence",
     "name": "Bamboo Fence",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_fence_gate",
     "name": "Bamboo Fence Gate",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_hanging_sign",
     "name": "Bamboo Hanging Sign",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_mosaic",
     "name": "Bamboo Mosaic",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_mosaic_slab",
     "name": "Bamboo Mosaic Slab",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_mosaic_stairs",
     "name": "Bamboo Mosaic Stairs",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_planks",
     "name": "Bamboo Planks",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_pressure_plate",
     "name": "Bamboo Pressure Plate",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_raft",
     "name": "Bamboo Raft",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_sign",
     "name": "Bamboo Sign",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_slab",
     "name": "Bamboo Slab",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_stairs",
     "name": "Bamboo Stairs",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "bamboo_trapdoor",
     "name": "Bamboo Trapdoor",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "barrel",
     "name": "Barrel",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "barrier",
     "name": "Barrier",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "basalt",
     "name": "Basalt",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "bat_spawn_egg",
     "name": "Bat Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "beacon",
     "name": "Beacon",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "epic"
   },
   {
     "id": "bedrock",
     "name": "Bedrock",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "bee_nest",
     "name": "Bee Nest",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "bee_spawn_egg",
     "name": "Bee Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "beef",
     "name": "Beef",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "beehive",
     "name": "Beehive",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "beetroot",
     "name": "Beetroot",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "beetroot_seeds",
     "name": "Beetroot Seeds",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "beetroot_soup",
     "name": "Beetroot Soup",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "bell",
     "name": "Bell",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "big_dripleaf",
     "name": "Big Dripleaf",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "birch_boat",
     "name": "Birch Boat",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_button",
     "name": "Birch Button",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_chest_boat",
     "name": "Birch Chest Boat",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_door",
     "name": "Birch Door",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_fence",
     "name": "Birch Fence",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_fence_gate",
     "name": "Birch Fence Gate",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_hanging_sign",
     "name": "Birch Hanging Sign",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_leaves",
     "name": "Birch Leaves",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_log",
     "name": "Birch Log",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_planks",
     "name": "Birch Planks",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_pressure_plate",
     "name": "Birch Pressure Plate",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_sapling",
     "name": "Birch Sapling",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_sign",
     "name": "Birch Sign",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_slab",
     "name": "Birch Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_stairs",
     "name": "Birch Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_trapdoor",
     "name": "Birch Trapdoor",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "birch_wood",
     "name": "Birch Wood",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "black_banner",
     "name": "Black Banner",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "black_bed",
     "name": "Black Bed",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "black_candle",
     "name": "Black Candle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "black_carpet",
     "name": "Black Carpet",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "black_concrete",
     "name": "Black Concrete",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "black_concrete_powder",
     "name": "Black Concrete Powder",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "black_dye",
     "name": "Black Dye",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "black_glazed_terracotta",
     "name": "Black Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "black_shulker_box",
     "name": "Black Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "black_stained_glass",
     "name": "Black Stained Glass",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "black_stained_glass_pane",
     "name": "Black Stained Glass Pane",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "black_terracotta",
     "name": "Black Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "black_wool",
     "name": "Black Wool",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "blackstone",
     "name": "Blackstone",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "blackstone_slab",
     "name": "Blackstone Slab",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "blackstone_stairs",
     "name": "Blackstone Stairs",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "blackstone_wall",
     "name": "Blackstone Wall",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "blade_pottery_sherd",
     "name": "Blade Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "blast_furnace",
     "name": "Blast Furnace",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "blaze_powder",
     "name": "Blaze Powder",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "blaze_rod",
     "name": "Blaze Rod",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "blaze_spawn_egg",
     "name": "Blaze Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "blue_banner",
     "name": "Blue Banner",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "blue_bed",
     "name": "Blue Bed",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "blue_candle",
     "name": "Blue Candle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "blue_carpet",
     "name": "Blue Carpet",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "blue_concrete",
     "name": "Blue Concrete",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "blue_concrete_powder",
     "name": "Blue Concrete Powder",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "blue_dye",
     "name": "Blue Dye",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "blue_glazed_terracotta",
     "name": "Blue Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "blue_ice",
     "name": "Blue Ice",
     "isEligible": false,
-    "category": "cold"
+    "category": "cold",
+    "rarity": "rare"
   },
   {
     "id": "blue_orchid",
     "name": "Blue Orchid",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "blue_shulker_box",
     "name": "Blue Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "blue_stained_glass",
     "name": "Blue Stained Glass",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "blue_stained_glass_pane",
     "name": "Blue Stained Glass Pane",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "blue_terracotta",
     "name": "Blue Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "blue_wool",
     "name": "Blue Wool",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "bone",
     "name": "Bone",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "bone_block",
     "name": "Bone Block",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "bone_meal",
     "name": "Bone Meal",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "book",
     "name": "Book",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "bookshelf",
     "name": "Bookshelf",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "bow",
     "name": "Bow",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "bowl",
     "name": "Bowl",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "brain_coral",
     "name": "Brain Coral",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "brain_coral_block",
     "name": "Brain Coral Block",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "brain_coral_fan",
     "name": "Brain Coral Fan",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "bread",
     "name": "Bread",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "brewer_pottery_sherd",
     "name": "Brewer Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "brewing_stand",
     "name": "Brewing Stand",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "brick",
     "name": "Brick",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "brick_slab",
     "name": "Brick Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "brick_stairs",
     "name": "Brick Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "brick_wall",
     "name": "Brick Wall",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "bricks",
     "name": "Bricks",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "brown_banner",
     "name": "Brown Banner",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "brown_bed",
     "name": "Brown Bed",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "brown_candle",
     "name": "Brown Candle",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "brown_carpet",
     "name": "Brown Carpet",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "brown_concrete",
     "name": "Brown Concrete",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "brown_concrete_powder",
     "name": "Brown Concrete Powder",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "brown_dye",
     "name": "Brown Dye",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "brown_glazed_terracotta",
     "name": "Brown Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "brown_mushroom",
     "name": "Brown Mushroom",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "brown_mushroom_block",
     "name": "Brown Mushroom Block",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "brown_shulker_box",
     "name": "Brown Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "brown_stained_glass",
     "name": "Brown Stained Glass",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "brown_stained_glass_pane",
     "name": "Brown Stained Glass Pane",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "brown_terracotta",
     "name": "Brown Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "brown_wool",
     "name": "Brown Wool",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "brush",
     "name": "Brush",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "bubble_coral",
     "name": "Bubble Coral",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "bubble_coral_block",
     "name": "Bubble Coral Block",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "bubble_coral_fan",
     "name": "Bubble Coral Fan",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "bucket",
     "name": "Bucket",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "budding_amethyst",
     "name": "Budding Amethyst",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "bundle",
     "name": "Bundle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "burn_pottery_sherd",
     "name": "Burn Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "cactus",
     "name": "Cactus",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "cake",
     "name": "Cake",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "calcite",
     "name": "Calcite",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "calibrated_sculk_sensor",
     "name": "Calibrated Sculk Sensor",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "camel_spawn_egg",
     "name": "Camel Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "campfire",
     "name": "Campfire",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "candle",
     "name": "Candle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "carrot",
     "name": "Carrot",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "carrot_on_a_stick",
     "name": "Carrot On A Stick",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "cartography_table",
     "name": "Cartography Table",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "carved_pumpkin",
     "name": "Carved Pumpkin",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cat_spawn_egg",
     "name": "Cat Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "cauldron",
     "name": "Cauldron",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cave_spider_spawn_egg",
     "name": "Cave Spider Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "chain",
     "name": "Chain",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "chain_command_block",
     "name": "Chain Command Block",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "chainmail_boots",
     "name": "Chainmail Boots",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "chainmail_chestplate",
     "name": "Chainmail Chestplate",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "chainmail_helmet",
     "name": "Chainmail Helmet",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "chainmail_leggings",
     "name": "Chainmail Leggings",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "charcoal",
     "name": "Charcoal",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cherry_boat",
     "name": "Cherry Boat",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_button",
     "name": "Cherry Button",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_chest_boat",
     "name": "Cherry Chest Boat",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_door",
     "name": "Cherry Door",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_fence",
     "name": "Cherry Fence",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_fence_gate",
     "name": "Cherry Fence Gate",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_hanging_sign",
     "name": "Cherry Hanging Sign",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_leaves",
     "name": "Cherry Leaves",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_log",
     "name": "Cherry Log",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_planks",
     "name": "Cherry Planks",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_pressure_plate",
     "name": "Cherry Pressure Plate",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_sapling",
     "name": "Cherry Sapling",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_sign",
     "name": "Cherry Sign",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_slab",
     "name": "Cherry Slab",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_stairs",
     "name": "Cherry Stairs",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_trapdoor",
     "name": "Cherry Trapdoor",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "cherry_wood",
     "name": "Cherry Wood",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "chest",
     "name": "Chest",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "chest_minecart",
     "name": "Chest Minecart",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "chicken",
     "name": "Chicken",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "chicken_spawn_egg",
     "name": "Chicken Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "chipped_anvil",
     "name": "Chipped Anvil",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "chiseled_bookshelf",
     "name": "Chiseled Bookshelf",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "chiseled_deepslate",
     "name": "Chiseled Deepslate",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "chiseled_nether_bricks",
     "name": "Chiseled Nether Bricks",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "chiseled_polished_blackstone",
     "name": "Chiseled Polished Blackstone",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "chiseled_quartz_block",
     "name": "Chiseled Quartz Block",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "chiseled_red_sandstone",
     "name": "Chiseled Red Sandstone",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "chiseled_sandstone",
     "name": "Chiseled Sandstone",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "chiseled_stone_bricks",
     "name": "Chiseled Stone Bricks",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "chorus_flower",
     "name": "Chorus Flower",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "chorus_fruit",
     "name": "Chorus Fruit",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "chorus_plant",
     "name": "Chorus Plant",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "clay",
     "name": "Clay",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "clay_ball",
     "name": "Clay Ball",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "clock",
     "name": "Clock",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "coal",
     "name": "Coal",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "coal_block",
     "name": "Coal Block",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "coal_ore",
     "name": "Coal Ore",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "coarse_dirt",
     "name": "Coarse Dirt",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "coast_armor_trim_smithing_template",
     "name": "Coast Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "cobbled_deepslate",
     "name": "Cobbled Deepslate",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "cobbled_deepslate_slab",
     "name": "Cobbled Deepslate Slab",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "cobbled_deepslate_stairs",
     "name": "Cobbled Deepslate Stairs",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "cobbled_deepslate_wall",
     "name": "Cobbled Deepslate Wall",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "cobblestone",
     "name": "Cobblestone",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cobblestone_slab",
     "name": "Cobblestone Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cobblestone_stairs",
     "name": "Cobblestone Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cobblestone_wall",
     "name": "Cobblestone Wall",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cobweb",
     "name": "Cobweb",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "cocoa_beans",
     "name": "Cocoa Beans",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "cod",
     "name": "Cod",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cod_bucket",
     "name": "Cod Bucket",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cod_spawn_egg",
     "name": "Cod Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "command_block",
     "name": "Command Block",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "command_block_minecart",
     "name": "Command Block Minecart",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "comparator",
     "name": "Comparator",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "compass",
     "name": "Compass",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "composter",
     "name": "Composter",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "conduit",
     "name": "Conduit",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "cooked_beef",
     "name": "Cooked Beef",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cooked_chicken",
     "name": "Cooked Chicken",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cooked_cod",
     "name": "Cooked Cod",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cooked_mutton",
     "name": "Cooked Mutton",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cooked_porkchop",
     "name": "Cooked Porkchop",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cooked_rabbit",
     "name": "Cooked Rabbit",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cooked_salmon",
     "name": "Cooked Salmon",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cookie",
     "name": "Cookie",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "copper_block",
     "name": "Copper Block",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "copper_ingot",
     "name": "Copper Ingot",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "copper_ore",
     "name": "Copper Ore",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "cornflower",
     "name": "Cornflower",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cow_spawn_egg",
     "name": "Cow Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "cracked_deepslate_bricks",
     "name": "Cracked Deepslate Bricks",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "cracked_deepslate_tiles",
     "name": "Cracked Deepslate Tiles",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "cracked_nether_bricks",
     "name": "Cracked Nether Bricks",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "cracked_polished_blackstone_bricks",
     "name": "Cracked Polished Blackstone Bricks",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "cracked_stone_bricks",
     "name": "Cracked Stone Bricks",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "crafting_table",
     "name": "Crafting Table",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "creeper_banner_pattern",
     "name": "Creeper Banner Pattern",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "creeper_head",
     "name": "Creeper Head",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "creeper_spawn_egg",
     "name": "Creeper Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "crimson_button",
     "name": "Crimson Button",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crimson_door",
     "name": "Crimson Door",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crimson_fence",
     "name": "Crimson Fence",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crimson_fence_gate",
     "name": "Crimson Fence Gate",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crimson_fungus",
     "name": "Crimson Fungus",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crimson_hanging_sign",
     "name": "Crimson Hanging Sign",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crimson_hyphae",
     "name": "Crimson Hyphae",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crimson_nylium",
     "name": "Crimson Nylium",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crimson_planks",
     "name": "Crimson Planks",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crimson_pressure_plate",
     "name": "Crimson Pressure Plate",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crimson_roots",
     "name": "Crimson Roots",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crimson_sign",
     "name": "Crimson Sign",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crimson_slab",
     "name": "Crimson Slab",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crimson_stairs",
     "name": "Crimson Stairs",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crimson_stem",
     "name": "Crimson Stem",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crimson_trapdoor",
     "name": "Crimson Trapdoor",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "crossbow",
     "name": "Crossbow",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "crying_obsidian",
     "name": "Crying Obsidian",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "cut_copper",
     "name": "Cut Copper",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cut_copper_slab",
     "name": "Cut Copper Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cut_copper_stairs",
     "name": "Cut Copper Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cut_red_sandstone",
     "name": "Cut Red Sandstone",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "cut_red_sandstone_slab",
     "name": "Cut Red Sandstone Slab",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "cut_sandstone",
     "name": "Cut Sandstone",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cut_sandstone_slab",
     "name": "Cut Sandstone Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "cyan_banner",
     "name": "Cyan Banner",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "cyan_bed",
     "name": "Cyan Bed",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "cyan_candle",
     "name": "Cyan Candle",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "cyan_carpet",
     "name": "Cyan Carpet",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "cyan_concrete",
     "name": "Cyan Concrete",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "cyan_concrete_powder",
     "name": "Cyan Concrete Powder",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "cyan_dye",
     "name": "Cyan Dye",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "cyan_glazed_terracotta",
     "name": "Cyan Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "cyan_shulker_box",
     "name": "Cyan Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "cyan_stained_glass",
     "name": "Cyan Stained Glass",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "cyan_stained_glass_pane",
     "name": "Cyan Stained Glass Pane",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "cyan_terracotta",
     "name": "Cyan Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "cyan_wool",
     "name": "Cyan Wool",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "damaged_anvil",
     "name": "Damaged Anvil",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "dandelion",
     "name": "Dandelion",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "danger_pottery_sherd",
     "name": "Danger Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_boat",
     "name": "Dark Oak Boat",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_button",
     "name": "Dark Oak Button",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_chest_boat",
     "name": "Dark Oak Chest Boat",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_door",
     "name": "Dark Oak Door",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_fence",
     "name": "Dark Oak Fence",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_fence_gate",
     "name": "Dark Oak Fence Gate",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_hanging_sign",
     "name": "Dark Oak Hanging Sign",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_leaves",
     "name": "Dark Oak Leaves",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_log",
     "name": "Dark Oak Log",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_planks",
     "name": "Dark Oak Planks",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_pressure_plate",
     "name": "Dark Oak Pressure Plate",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_sapling",
     "name": "Dark Oak Sapling",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_sign",
     "name": "Dark Oak Sign",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_slab",
     "name": "Dark Oak Slab",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_stairs",
     "name": "Dark Oak Stairs",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_trapdoor",
     "name": "Dark Oak Trapdoor",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_oak_wood",
     "name": "Dark Oak Wood",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "dark_prismarine",
     "name": "Dark Prismarine",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dark_prismarine_slab",
     "name": "Dark Prismarine Slab",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dark_prismarine_stairs",
     "name": "Dark Prismarine Stairs",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "daylight_detector",
     "name": "Daylight Detector",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "dead_brain_coral",
     "name": "Dead Brain Coral",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dead_brain_coral_block",
     "name": "Dead Brain Coral Block",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dead_brain_coral_fan",
     "name": "Dead Brain Coral Fan",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dead_bubble_coral",
     "name": "Dead Bubble Coral",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dead_bubble_coral_block",
     "name": "Dead Bubble Coral Block",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dead_bubble_coral_fan",
     "name": "Dead Bubble Coral Fan",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dead_bush",
     "name": "Dead Bush",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "dead_fire_coral",
     "name": "Dead Fire Coral",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dead_fire_coral_block",
     "name": "Dead Fire Coral Block",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dead_fire_coral_fan",
     "name": "Dead Fire Coral Fan",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dead_horn_coral",
     "name": "Dead Horn Coral",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dead_horn_coral_block",
     "name": "Dead Horn Coral Block",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dead_horn_coral_fan",
     "name": "Dead Horn Coral Fan",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dead_tube_coral",
     "name": "Dead Tube Coral",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dead_tube_coral_block",
     "name": "Dead Tube Coral Block",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dead_tube_coral_fan",
     "name": "Dead Tube Coral Fan",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "debug_stick",
     "name": "Debug Stick",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "decorated_pot",
     "name": "Decorated Pot",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "deepslate",
     "name": "Deepslate",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_brick_slab",
     "name": "Deepslate Brick Slab",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_brick_stairs",
     "name": "Deepslate Brick Stairs",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_brick_wall",
     "name": "Deepslate Brick Wall",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_bricks",
     "name": "Deepslate Bricks",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_coal_ore",
     "name": "Deepslate Coal Ore",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_copper_ore",
     "name": "Deepslate Copper Ore",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_diamond_ore",
     "name": "Deepslate Diamond Ore",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_emerald_ore",
     "name": "Deepslate Emerald Ore",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_gold_ore",
     "name": "Deepslate Gold Ore",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_iron_ore",
     "name": "Deepslate Iron Ore",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_lapis_ore",
     "name": "Deepslate Lapis Ore",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_redstone_ore",
     "name": "Deepslate Redstone Ore",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_tile_slab",
     "name": "Deepslate Tile Slab",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_tile_stairs",
     "name": "Deepslate Tile Stairs",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_tile_wall",
     "name": "Deepslate Tile Wall",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "deepslate_tiles",
     "name": "Deepslate Tiles",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "detector_rail",
     "name": "Detector Rail",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "diamond",
     "name": "Diamond",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "diamond_axe",
     "name": "Diamond Axe",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "diamond_block",
     "name": "Diamond Block",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "diamond_boots",
     "name": "Diamond Boots",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "diamond_chestplate",
     "name": "Diamond Chestplate",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "diamond_helmet",
     "name": "Diamond Helmet",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "diamond_hoe",
     "name": "Diamond Hoe",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "diamond_horse_armor",
     "name": "Diamond Horse Armor",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "diamond_leggings",
     "name": "Diamond Leggings",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "diamond_ore",
     "name": "Diamond Ore",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "diamond_pickaxe",
     "name": "Diamond Pickaxe",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "diamond_shovel",
     "name": "Diamond Shovel",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "diamond_sword",
     "name": "Diamond Sword",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "diorite",
     "name": "Diorite",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "diorite_slab",
     "name": "Diorite Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "diorite_stairs",
     "name": "Diorite Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "diorite_wall",
     "name": "Diorite Wall",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "dirt",
     "name": "Dirt",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "dirt_path",
     "name": "Dirt Path",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "disc_fragment_5",
     "name": "Disc Fragment 5",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "dispenser",
     "name": "Dispenser",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "dolphin_spawn_egg",
     "name": "Dolphin Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "donkey_spawn_egg",
     "name": "Donkey Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "dragon_breath",
     "name": "Dragon Breath",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "dragon_egg",
     "name": "Dragon Egg",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "epic"
   },
   {
     "id": "dragon_head",
     "name": "Dragon Head",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "epic"
   },
   {
     "id": "dried_kelp",
     "name": "Dried Kelp",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dried_kelp_block",
     "name": "Dried Kelp Block",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "dripstone_block",
     "name": "Dripstone Block",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "dropper",
     "name": "Dropper",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "drowned_spawn_egg",
     "name": "Drowned Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "dune_armor_trim_smithing_template",
     "name": "Dune Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "echo_shard",
     "name": "Echo Shard",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "egg",
     "name": "Egg",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "elder_guardian_spawn_egg",
     "name": "Elder Guardian Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "elytra",
     "name": "Elytra",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "epic"
   },
   {
     "id": "emerald",
     "name": "Emerald",
     "isEligible": false,
-    "category": "mountain"
+    "category": "mountain",
+    "rarity": "rare"
   },
   {
     "id": "emerald_block",
     "name": "Emerald Block",
     "isEligible": false,
-    "category": "mountain"
+    "category": "mountain",
+    "rarity": "rare"
   },
   {
     "id": "emerald_ore",
     "name": "Emerald Ore",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "enchanted_book",
     "name": "Enchanted Book",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "enchanted_golden_apple",
     "name": "Enchanted Golden Apple",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "epic"
   },
   {
     "id": "enchanting_table",
     "name": "Enchanting Table",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "end_crystal",
     "name": "End Crystal",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "end_portal_frame",
     "name": "End Portal Frame",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "end_rod",
     "name": "End Rod",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "end_stone",
     "name": "End Stone",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "end_stone_brick_slab",
     "name": "End Stone Brick Slab",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "end_stone_brick_stairs",
     "name": "End Stone Brick Stairs",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "end_stone_brick_wall",
     "name": "End Stone Brick Wall",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "end_stone_bricks",
     "name": "End Stone Bricks",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "ender_chest",
     "name": "Ender Chest",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "ender_dragon_spawn_egg",
     "name": "Ender Dragon Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "ender_eye",
     "name": "Ender Eye",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "ender_pearl",
     "name": "Ender Pearl",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "enderman_spawn_egg",
     "name": "Enderman Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "endermite_spawn_egg",
     "name": "Endermite Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "evoker_spawn_egg",
     "name": "Evoker Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "experience_bottle",
     "name": "Experience Bottle",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "explorer_pottery_sherd",
     "name": "Explorer Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "exposed_copper",
     "name": "Exposed Copper",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "exposed_cut_copper",
     "name": "Exposed Cut Copper",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "exposed_cut_copper_slab",
     "name": "Exposed Cut Copper Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "exposed_cut_copper_stairs",
     "name": "Exposed Cut Copper Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "eye_armor_trim_smithing_template",
     "name": "Eye Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "farmland",
     "name": "Farmland",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "feather",
     "name": "Feather",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "fermented_spider_eye",
     "name": "Fermented Spider Eye",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "fern",
     "name": "Fern",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "filled_map",
     "name": "Filled Map",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "fire_charge",
     "name": "Fire Charge",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "fire_coral",
     "name": "Fire Coral",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "fire_coral_block",
     "name": "Fire Coral Block",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "fire_coral_fan",
     "name": "Fire Coral Fan",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "firework_rocket",
     "name": "Firework Rocket",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "firework_star",
     "name": "Firework Star",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "fishing_rod",
     "name": "Fishing Rod",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "fletching_table",
     "name": "Fletching Table",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "flint",
     "name": "Flint",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "flint_and_steel",
     "name": "Flint And Steel",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "flower_banner_pattern",
     "name": "Flower Banner Pattern",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "flower_pot",
     "name": "Flower Pot",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "flowering_azalea",
     "name": "Flowering Azalea",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "flowering_azalea_leaves",
     "name": "Flowering Azalea Leaves",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "fox_spawn_egg",
     "name": "Fox Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "friend_pottery_sherd",
     "name": "Friend Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "frog_spawn_egg",
     "name": "Frog Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "frogspawn",
     "name": "Frogspawn",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "furnace",
     "name": "Furnace",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "furnace_minecart",
     "name": "Furnace Minecart",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "ghast_spawn_egg",
     "name": "Ghast Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "ghast_tear",
     "name": "Ghast Tear",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "gilded_blackstone",
     "name": "Gilded Blackstone",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "glass",
     "name": "Glass",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "glass_bottle",
     "name": "Glass Bottle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "glass_pane",
     "name": "Glass Pane",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "glistering_melon_slice",
     "name": "Glistering Melon Slice",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "globe_banner_pattern",
     "name": "Globe Banner Pattern",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "glow_berries",
     "name": "Glow Berries",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "glow_ink_sac",
     "name": "Glow Ink Sac",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "glow_item_frame",
     "name": "Glow Item Frame",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "glow_lichen",
     "name": "Glow Lichen",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "glow_squid_spawn_egg",
     "name": "Glow Squid Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "glowstone",
     "name": "Glowstone",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "glowstone_dust",
     "name": "Glowstone Dust",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "goat_horn",
     "name": "Goat Horn",
     "isEligible": false,
-    "category": "mountain"
+    "category": "mountain",
+    "rarity": "rare"
   },
   {
     "id": "goat_spawn_egg",
     "name": "Goat Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "gold_block",
     "name": "Gold Block",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "gold_ingot",
     "name": "Gold Ingot",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "gold_nugget",
     "name": "Gold Nugget",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "gold_ore",
     "name": "Gold Ore",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "golden_apple",
     "name": "Golden Apple",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "golden_axe",
     "name": "Golden Axe",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "golden_boots",
     "name": "Golden Boots",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "golden_carrot",
     "name": "Golden Carrot",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "golden_chestplate",
     "name": "Golden Chestplate",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "golden_helmet",
     "name": "Golden Helmet",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "golden_hoe",
     "name": "Golden Hoe",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "golden_horse_armor",
     "name": "Golden Horse Armor",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "golden_leggings",
     "name": "Golden Leggings",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "golden_pickaxe",
     "name": "Golden Pickaxe",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "golden_shovel",
     "name": "Golden Shovel",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "golden_sword",
     "name": "Golden Sword",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "granite",
     "name": "Granite",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "granite_slab",
     "name": "Granite Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "granite_stairs",
     "name": "Granite Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "granite_wall",
     "name": "Granite Wall",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "grass",
     "name": "Grass",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "grass_block",
     "name": "Grass Block",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "gravel",
     "name": "Gravel",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "gray_banner",
     "name": "Gray Banner",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "gray_bed",
     "name": "Gray Bed",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "gray_candle",
     "name": "Gray Candle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "gray_carpet",
     "name": "Gray Carpet",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "gray_concrete",
     "name": "Gray Concrete",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "gray_concrete_powder",
     "name": "Gray Concrete Powder",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "gray_dye",
     "name": "Gray Dye",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "gray_glazed_terracotta",
     "name": "Gray Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "gray_shulker_box",
     "name": "Gray Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "gray_stained_glass",
     "name": "Gray Stained Glass",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "gray_stained_glass_pane",
     "name": "Gray Stained Glass Pane",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "gray_terracotta",
     "name": "Gray Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "gray_wool",
     "name": "Gray Wool",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "green_banner",
     "name": "Green Banner",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "green_bed",
     "name": "Green Bed",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "green_candle",
     "name": "Green Candle",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "green_carpet",
     "name": "Green Carpet",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "green_concrete",
     "name": "Green Concrete",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "green_concrete_powder",
     "name": "Green Concrete Powder",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "green_dye",
     "name": "Green Dye",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "green_glazed_terracotta",
     "name": "Green Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "green_shulker_box",
     "name": "Green Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "green_stained_glass",
     "name": "Green Stained Glass",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "green_stained_glass_pane",
     "name": "Green Stained Glass Pane",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "green_terracotta",
     "name": "Green Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "green_wool",
     "name": "Green Wool",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "grindstone",
     "name": "Grindstone",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "guardian_spawn_egg",
     "name": "Guardian Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "gunpowder",
     "name": "Gunpowder",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "hanging_roots",
     "name": "Hanging Roots",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "hay_block",
     "name": "Hay Block",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "heart_of_the_sea",
     "name": "Heart Of The Sea",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "heart_pottery_sherd",
     "name": "Heart Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "heartbreak_pottery_sherd",
     "name": "Heartbreak Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "heavy_weighted_pressure_plate",
     "name": "Heavy Weighted Pressure Plate",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "hoglin_spawn_egg",
     "name": "Hoglin Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "honey_block",
     "name": "Honey Block",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "honey_bottle",
     "name": "Honey Bottle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "honeycomb",
     "name": "Honeycomb",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "honeycomb_block",
     "name": "Honeycomb Block",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "hopper",
     "name": "Hopper",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "hopper_minecart",
     "name": "Hopper Minecart",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "horn_coral",
     "name": "Horn Coral",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "horn_coral_block",
     "name": "Horn Coral Block",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "horn_coral_fan",
     "name": "Horn Coral Fan",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "horse_spawn_egg",
     "name": "Horse Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "host_armor_trim_smithing_template",
     "name": "Host Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "howl_pottery_sherd",
     "name": "Howl Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "husk_spawn_egg",
     "name": "Husk Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "ice",
     "name": "Ice",
     "isEligible": false,
-    "category": "cold"
+    "category": "cold",
+    "rarity": "rare"
   },
   {
     "id": "infested_chiseled_stone_bricks",
     "name": "Infested Chiseled Stone Bricks",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "infested_cobblestone",
     "name": "Infested Cobblestone",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "infested_cracked_stone_bricks",
     "name": "Infested Cracked Stone Bricks",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "infested_deepslate",
     "name": "Infested Deepslate",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "infested_mossy_stone_bricks",
     "name": "Infested Mossy Stone Bricks",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "infested_stone",
     "name": "Infested Stone",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "infested_stone_bricks",
     "name": "Infested Stone Bricks",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "ink_sac",
     "name": "Ink Sac",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "iron_axe",
     "name": "Iron Axe",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "iron_bars",
     "name": "Iron Bars",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "iron_block",
     "name": "Iron Block",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "iron_boots",
     "name": "Iron Boots",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "iron_chestplate",
     "name": "Iron Chestplate",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "iron_door",
     "name": "Iron Door",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "iron_golem_spawn_egg",
     "name": "Iron Golem Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "iron_helmet",
     "name": "Iron Helmet",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "iron_hoe",
     "name": "Iron Hoe",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "iron_horse_armor",
     "name": "Iron Horse Armor",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "iron_ingot",
     "name": "Iron Ingot",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "iron_leggings",
     "name": "Iron Leggings",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "iron_nugget",
     "name": "Iron Nugget",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "iron_ore",
     "name": "Iron Ore",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "iron_pickaxe",
     "name": "Iron Pickaxe",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "iron_shovel",
     "name": "Iron Shovel",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "iron_sword",
     "name": "Iron Sword",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "iron_trapdoor",
     "name": "Iron Trapdoor",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "item_frame",
     "name": "Item Frame",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "jack_o_lantern",
     "name": "Jack O Lantern",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "jigsaw",
     "name": "Jigsaw",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "jukebox",
     "name": "Jukebox",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "jungle_boat",
     "name": "Jungle Boat",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_button",
     "name": "Jungle Button",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_chest_boat",
     "name": "Jungle Chest Boat",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_door",
     "name": "Jungle Door",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_fence",
     "name": "Jungle Fence",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_fence_gate",
     "name": "Jungle Fence Gate",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_hanging_sign",
     "name": "Jungle Hanging Sign",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_leaves",
     "name": "Jungle Leaves",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_log",
     "name": "Jungle Log",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_planks",
     "name": "Jungle Planks",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_pressure_plate",
     "name": "Jungle Pressure Plate",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_sapling",
     "name": "Jungle Sapling",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_sign",
     "name": "Jungle Sign",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_slab",
     "name": "Jungle Slab",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_stairs",
     "name": "Jungle Stairs",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_trapdoor",
     "name": "Jungle Trapdoor",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "jungle_wood",
     "name": "Jungle Wood",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "kelp",
     "name": "Kelp",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "knowledge_book",
     "name": "Knowledge Book",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "ladder",
     "name": "Ladder",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "lantern",
     "name": "Lantern",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "lapis_block",
     "name": "Lapis Block",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "lapis_lazuli",
     "name": "Lapis Lazuli",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "lapis_ore",
     "name": "Lapis Ore",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "large_amethyst_bud",
     "name": "Large Amethyst Bud",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "large_fern",
     "name": "Large Fern",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "lava_bucket",
     "name": "Lava Bucket",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "lead",
     "name": "Lead",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "leather",
     "name": "Leather",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "leather_boots",
     "name": "Leather Boots",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "leather_chestplate",
     "name": "Leather Chestplate",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "leather_helmet",
     "name": "Leather Helmet",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "leather_horse_armor",
     "name": "Leather Horse Armor",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "leather_leggings",
     "name": "Leather Leggings",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "lectern",
     "name": "Lectern",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "lever",
     "name": "Lever",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light",
     "name": "Light",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "light_blue_banner",
     "name": "Light Blue Banner",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_blue_bed",
     "name": "Light Blue Bed",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_blue_candle",
     "name": "Light Blue Candle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_blue_carpet",
     "name": "Light Blue Carpet",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_blue_concrete",
     "name": "Light Blue Concrete",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_blue_concrete_powder",
     "name": "Light Blue Concrete Powder",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_blue_dye",
     "name": "Light Blue Dye",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_blue_glazed_terracotta",
     "name": "Light Blue Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "light_blue_shulker_box",
     "name": "Light Blue Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "light_blue_stained_glass",
     "name": "Light Blue Stained Glass",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_blue_stained_glass_pane",
     "name": "Light Blue Stained Glass Pane",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_blue_terracotta",
     "name": "Light Blue Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "light_blue_wool",
     "name": "Light Blue Wool",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_gray_banner",
     "name": "Light Gray Banner",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_gray_bed",
     "name": "Light Gray Bed",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_gray_candle",
     "name": "Light Gray Candle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_gray_carpet",
     "name": "Light Gray Carpet",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_gray_concrete",
     "name": "Light Gray Concrete",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_gray_concrete_powder",
     "name": "Light Gray Concrete Powder",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_gray_dye",
     "name": "Light Gray Dye",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_gray_glazed_terracotta",
     "name": "Light Gray Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "light_gray_shulker_box",
     "name": "Light Gray Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "light_gray_stained_glass",
     "name": "Light Gray Stained Glass",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_gray_stained_glass_pane",
     "name": "Light Gray Stained Glass Pane",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_gray_terracotta",
     "name": "Light Gray Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "light_gray_wool",
     "name": "Light Gray Wool",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "light_weighted_pressure_plate",
     "name": "Light Weighted Pressure Plate",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "lightning_rod",
     "name": "Lightning Rod",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "lilac",
     "name": "Lilac",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "lily_of_the_valley",
     "name": "Lily Of The Valley",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "lily_pad",
     "name": "Lily Pad",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "lime_banner",
     "name": "Lime Banner",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "lime_bed",
     "name": "Lime Bed",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "lime_candle",
     "name": "Lime Candle",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "lime_carpet",
     "name": "Lime Carpet",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "lime_concrete",
     "name": "Lime Concrete",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "lime_concrete_powder",
     "name": "Lime Concrete Powder",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "lime_dye",
     "name": "Lime Dye",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "lime_glazed_terracotta",
     "name": "Lime Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "lime_shulker_box",
     "name": "Lime Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "lime_stained_glass",
     "name": "Lime Stained Glass",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "lime_stained_glass_pane",
     "name": "Lime Stained Glass Pane",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "lime_terracotta",
     "name": "Lime Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "lime_wool",
     "name": "Lime Wool",
     "isEligible": false,
-    "category": "desert"
+    "category": "desert",
+    "rarity": "rare"
   },
   {
     "id": "lingering_potion",
     "name": "Lingering Potion",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "llama_spawn_egg",
     "name": "Llama Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "lodestone",
     "name": "Lodestone",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "loom",
     "name": "Loom",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "magenta_banner",
     "name": "Magenta Banner",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "magenta_bed",
     "name": "Magenta Bed",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "magenta_candle",
     "name": "Magenta Candle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "magenta_carpet",
     "name": "Magenta Carpet",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "magenta_concrete",
     "name": "Magenta Concrete",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "magenta_concrete_powder",
     "name": "Magenta Concrete Powder",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "magenta_dye",
     "name": "Magenta Dye",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "magenta_glazed_terracotta",
     "name": "Magenta Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "magenta_shulker_box",
     "name": "Magenta Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "magenta_stained_glass",
     "name": "Magenta Stained Glass",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "magenta_stained_glass_pane",
     "name": "Magenta Stained Glass Pane",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "magenta_terracotta",
     "name": "Magenta Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "magenta_wool",
     "name": "Magenta Wool",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "magma_block",
     "name": "Magma Block",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "magma_cream",
     "name": "Magma Cream",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "magma_cube_spawn_egg",
     "name": "Magma Cube Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "mangrove_boat",
     "name": "Mangrove Boat",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_button",
     "name": "Mangrove Button",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_chest_boat",
     "name": "Mangrove Chest Boat",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_door",
     "name": "Mangrove Door",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_fence",
     "name": "Mangrove Fence",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_fence_gate",
     "name": "Mangrove Fence Gate",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_hanging_sign",
     "name": "Mangrove Hanging Sign",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_leaves",
     "name": "Mangrove Leaves",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_log",
     "name": "Mangrove Log",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_planks",
     "name": "Mangrove Planks",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_pressure_plate",
     "name": "Mangrove Pressure Plate",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_propagule",
     "name": "Mangrove Propagule",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_roots",
     "name": "Mangrove Roots",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_sign",
     "name": "Mangrove Sign",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_slab",
     "name": "Mangrove Slab",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_stairs",
     "name": "Mangrove Stairs",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_trapdoor",
     "name": "Mangrove Trapdoor",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mangrove_wood",
     "name": "Mangrove Wood",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "map",
     "name": "Map",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "medium_amethyst_bud",
     "name": "Medium Amethyst Bud",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "melon",
     "name": "Melon",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "melon_seeds",
     "name": "Melon Seeds",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "melon_slice",
     "name": "Melon Slice",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "milk_bucket",
     "name": "Milk Bucket",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "minecart",
     "name": "Minecart",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "miner_pottery_sherd",
     "name": "Miner Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "mojang_banner_pattern",
     "name": "Mojang Banner Pattern",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "mooshroom_spawn_egg",
     "name": "Mooshroom Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "moss_block",
     "name": "Moss Block",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "moss_carpet",
     "name": "Moss Carpet",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "mossy_cobblestone",
     "name": "Mossy Cobblestone",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "mossy_cobblestone_slab",
     "name": "Mossy Cobblestone Slab",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "mossy_cobblestone_stairs",
     "name": "Mossy Cobblestone Stairs",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "mossy_cobblestone_wall",
     "name": "Mossy Cobblestone Wall",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "mossy_stone_brick_slab",
     "name": "Mossy Stone Brick Slab",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "mossy_stone_brick_stairs",
     "name": "Mossy Stone Brick Stairs",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "mossy_stone_brick_wall",
     "name": "Mossy Stone Brick Wall",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "mossy_stone_bricks",
     "name": "Mossy Stone Bricks",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "mourner_pottery_sherd",
     "name": "Mourner Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "mud",
     "name": "Mud",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "mud_brick_slab",
     "name": "Mud Brick Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "mud_brick_stairs",
     "name": "Mud Brick Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "mud_brick_wall",
     "name": "Mud Brick Wall",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "mud_bricks",
     "name": "Mud Bricks",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "muddy_mangrove_roots",
     "name": "Muddy Mangrove Roots",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "mule_spawn_egg",
     "name": "Mule Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "mushroom_stem",
     "name": "Mushroom Stem",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "music_disc_5",
     "name": "Music Disc 5",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "music_disc_11",
     "name": "Music Disc 11",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "music_disc_13",
     "name": "Music Disc 13",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "music_disc_blocks",
     "name": "Music Disc Blocks",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "music_disc_cat",
     "name": "Music Disc Cat",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "music_disc_chirp",
     "name": "Music Disc Chirp",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "music_disc_far",
     "name": "Music Disc Far",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "music_disc_mall",
     "name": "Music Disc Mall",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "music_disc_mellohi",
     "name": "Music Disc Mellohi",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "music_disc_otherside",
     "name": "Music Disc Otherside",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "music_disc_pigstep",
     "name": "Music Disc Pigstep",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "music_disc_relic",
     "name": "Music Disc Relic",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "music_disc_stal",
     "name": "Music Disc Stal",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "music_disc_strad",
     "name": "Music Disc Strad",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "music_disc_wait",
     "name": "Music Disc Wait",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "music_disc_ward",
     "name": "Music Disc Ward",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "mutton",
     "name": "Mutton",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "mycelium",
     "name": "Mycelium",
     "isEligible": false,
-    "category": "mushroom"
+    "category": "mushroom",
+    "rarity": "common"
   },
   {
     "id": "name_tag",
     "name": "Name Tag",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "nautilus_shell",
     "name": "Nautilus Shell",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "nether_brick",
     "name": "Nether Brick",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "nether_brick_fence",
     "name": "Nether Brick Fence",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "nether_brick_slab",
     "name": "Nether Brick Slab",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "nether_brick_stairs",
     "name": "Nether Brick Stairs",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "nether_brick_wall",
     "name": "Nether Brick Wall",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "nether_bricks",
     "name": "Nether Bricks",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "nether_gold_ore",
     "name": "Nether Gold Ore",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "nether_quartz_ore",
     "name": "Nether Quartz Ore",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "nether_sprouts",
     "name": "Nether Sprouts",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "nether_star",
     "name": "Nether Star",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "nether_wart",
     "name": "Nether Wart",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "nether_wart_block",
     "name": "Nether Wart Block",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "netherite_axe",
     "name": "Netherite Axe",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "epic"
   },
   {
     "id": "netherite_block",
     "name": "Netherite Block",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "netherite_boots",
     "name": "Netherite Boots",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "epic"
   },
   {
     "id": "netherite_chestplate",
     "name": "Netherite Chestplate",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "epic"
   },
   {
     "id": "netherite_helmet",
     "name": "Netherite Helmet",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "epic"
   },
   {
     "id": "netherite_hoe",
     "name": "Netherite Hoe",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "epic"
   },
   {
     "id": "netherite_ingot",
     "name": "Netherite Ingot",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "epic"
   },
   {
     "id": "netherite_leggings",
     "name": "Netherite Leggings",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "epic"
   },
   {
     "id": "netherite_pickaxe",
     "name": "Netherite Pickaxe",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "epic"
   },
   {
     "id": "netherite_scrap",
     "name": "Netherite Scrap",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "epic"
   },
   {
     "id": "netherite_shovel",
     "name": "Netherite Shovel",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "epic"
   },
   {
     "id": "netherite_sword",
     "name": "Netherite Sword",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "epic"
   },
   {
     "id": "netherite_upgrade_smithing_template",
     "name": "Netherite Upgrade Smithing Template",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "netherrack",
     "name": "Netherrack",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "note_block",
     "name": "Note Block",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "oak_boat",
     "name": "Oak Boat",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_button",
     "name": "Oak Button",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_chest_boat",
     "name": "Oak Chest Boat",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_door",
     "name": "Oak Door",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_fence",
     "name": "Oak Fence",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_fence_gate",
     "name": "Oak Fence Gate",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_hanging_sign",
     "name": "Oak Hanging Sign",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_leaves",
     "name": "Oak Leaves",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_log",
     "name": "Oak Log",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_planks",
     "name": "Oak Planks",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_pressure_plate",
     "name": "Oak Pressure Plate",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_sapling",
     "name": "Oak Sapling",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_sign",
     "name": "Oak Sign",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_slab",
     "name": "Oak Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_stairs",
     "name": "Oak Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_trapdoor",
     "name": "Oak Trapdoor",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oak_wood",
     "name": "Oak Wood",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "observer",
     "name": "Observer",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "obsidian",
     "name": "Obsidian",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "ocelot_spawn_egg",
     "name": "Ocelot Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "ochre_froglight",
     "name": "Ochre Froglight",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "orange_banner",
     "name": "Orange Banner",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "orange_bed",
     "name": "Orange Bed",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "orange_candle",
     "name": "Orange Candle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "orange_carpet",
     "name": "Orange Carpet",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "orange_concrete",
     "name": "Orange Concrete",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "orange_concrete_powder",
     "name": "Orange Concrete Powder",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "orange_dye",
     "name": "Orange Dye",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "orange_glazed_terracotta",
     "name": "Orange Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "orange_shulker_box",
     "name": "Orange Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "orange_stained_glass",
     "name": "Orange Stained Glass",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "orange_stained_glass_pane",
     "name": "Orange Stained Glass Pane",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "orange_terracotta",
     "name": "Orange Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "orange_tulip",
     "name": "Orange Tulip",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "orange_wool",
     "name": "Orange Wool",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oxeye_daisy",
     "name": "Oxeye Daisy",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oxidized_copper",
     "name": "Oxidized Copper",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oxidized_cut_copper",
     "name": "Oxidized Cut Copper",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oxidized_cut_copper_slab",
     "name": "Oxidized Cut Copper Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "oxidized_cut_copper_stairs",
     "name": "Oxidized Cut Copper Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "packed_ice",
     "name": "Packed Ice",
     "isEligible": false,
-    "category": "cold"
+    "category": "cold",
+    "rarity": "rare"
   },
   {
     "id": "packed_mud",
     "name": "Packed Mud",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "painting",
     "name": "Painting",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "panda_spawn_egg",
     "name": "Panda Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "paper",
     "name": "Paper",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "parrot_spawn_egg",
     "name": "Parrot Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "pearlescent_froglight",
     "name": "Pearlescent Froglight",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "peony",
     "name": "Peony",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "petrified_oak_slab",
     "name": "Petrified Oak Slab",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "phantom_membrane",
     "name": "Phantom Membrane",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "phantom_spawn_egg",
     "name": "Phantom Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "pig_spawn_egg",
     "name": "Pig Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "piglin_banner_pattern",
     "name": "Piglin Banner Pattern",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "piglin_brute_spawn_egg",
     "name": "Piglin Brute Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "piglin_head",
     "name": "Piglin Head",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "piglin_spawn_egg",
     "name": "Piglin Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "pillager_spawn_egg",
     "name": "Pillager Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "pink_banner",
     "name": "Pink Banner",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "pink_bed",
     "name": "Pink Bed",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "pink_candle",
     "name": "Pink Candle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "pink_carpet",
     "name": "Pink Carpet",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "pink_concrete",
     "name": "Pink Concrete",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "pink_concrete_powder",
     "name": "Pink Concrete Powder",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "pink_dye",
     "name": "Pink Dye",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "pink_glazed_terracotta",
     "name": "Pink Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "pink_petals",
     "name": "Pink Petals",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "pink_shulker_box",
     "name": "Pink Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "pink_stained_glass",
     "name": "Pink Stained Glass",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "pink_stained_glass_pane",
     "name": "Pink Stained Glass Pane",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "pink_terracotta",
     "name": "Pink Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "pink_tulip",
     "name": "Pink Tulip",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "pink_wool",
     "name": "Pink Wool",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "piston",
     "name": "Piston",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "pitcher_plant",
     "name": "Pitcher Plant",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "pitcher_pod",
     "name": "Pitcher Pod",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "player_head",
     "name": "Player Head",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "plenty_pottery_sherd",
     "name": "Plenty Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "podzol",
     "name": "Podzol",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "pointed_dripstone",
     "name": "Pointed Dripstone",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "poisonous_potato",
     "name": "Poisonous Potato",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "polar_bear_spawn_egg",
     "name": "Polar Bear Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "polished_andesite",
     "name": "Polished Andesite",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "polished_andesite_slab",
     "name": "Polished Andesite Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "polished_andesite_stairs",
     "name": "Polished Andesite Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "polished_basalt",
     "name": "Polished Basalt",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "polished_blackstone",
     "name": "Polished Blackstone",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "polished_blackstone_brick_slab",
     "name": "Polished Blackstone Brick Slab",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "polished_blackstone_brick_stairs",
     "name": "Polished Blackstone Brick Stairs",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "polished_blackstone_brick_wall",
     "name": "Polished Blackstone Brick Wall",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "polished_blackstone_bricks",
     "name": "Polished Blackstone Bricks",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "polished_blackstone_button",
     "name": "Polished Blackstone Button",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "polished_blackstone_pressure_plate",
     "name": "Polished Blackstone Pressure Plate",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "polished_blackstone_slab",
     "name": "Polished Blackstone Slab",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "polished_blackstone_stairs",
     "name": "Polished Blackstone Stairs",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "polished_blackstone_wall",
     "name": "Polished Blackstone Wall",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "polished_deepslate",
     "name": "Polished Deepslate",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "polished_deepslate_slab",
     "name": "Polished Deepslate Slab",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "polished_deepslate_stairs",
     "name": "Polished Deepslate Stairs",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "polished_deepslate_wall",
     "name": "Polished Deepslate Wall",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "polished_diorite",
     "name": "Polished Diorite",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "polished_diorite_slab",
     "name": "Polished Diorite Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "polished_diorite_stairs",
     "name": "Polished Diorite Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "polished_granite",
     "name": "Polished Granite",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "polished_granite_slab",
     "name": "Polished Granite Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "polished_granite_stairs",
     "name": "Polished Granite Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "popped_chorus_fruit",
     "name": "Popped Chorus Fruit",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "poppy",
     "name": "Poppy",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "porkchop",
     "name": "Porkchop",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "potato",
     "name": "Potato",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "potion",
     "name": "Potion",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "powder_snow_bucket",
     "name": "Powder Snow Bucket",
     "isEligible": false,
-    "category": "cold"
+    "category": "cold",
+    "rarity": "rare"
   },
   {
     "id": "powered_rail",
     "name": "Powered Rail",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "prismarine",
     "name": "Prismarine",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "prismarine_brick_slab",
     "name": "Prismarine Brick Slab",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "prismarine_brick_stairs",
     "name": "Prismarine Brick Stairs",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "prismarine_bricks",
     "name": "Prismarine Bricks",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "prismarine_crystals",
     "name": "Prismarine Crystals",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "prismarine_shard",
     "name": "Prismarine Shard",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "prismarine_slab",
     "name": "Prismarine Slab",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "prismarine_stairs",
     "name": "Prismarine Stairs",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "prismarine_wall",
     "name": "Prismarine Wall",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "prize_pottery_sherd",
     "name": "Prize Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "pufferfish",
     "name": "Pufferfish",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "pufferfish_bucket",
     "name": "Pufferfish Bucket",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "pufferfish_spawn_egg",
     "name": "Pufferfish Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "pumpkin",
     "name": "Pumpkin",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "pumpkin_pie",
     "name": "Pumpkin Pie",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "pumpkin_seeds",
     "name": "Pumpkin Seeds",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "purple_banner",
     "name": "Purple Banner",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "purple_bed",
     "name": "Purple Bed",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "purple_candle",
     "name": "Purple Candle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "purple_carpet",
     "name": "Purple Carpet",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "purple_concrete",
     "name": "Purple Concrete",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "purple_concrete_powder",
     "name": "Purple Concrete Powder",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "purple_dye",
     "name": "Purple Dye",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "purple_glazed_terracotta",
     "name": "Purple Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "purple_shulker_box",
     "name": "Purple Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "purple_stained_glass",
     "name": "Purple Stained Glass",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "purple_stained_glass_pane",
     "name": "Purple Stained Glass Pane",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "purple_terracotta",
     "name": "Purple Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "purple_wool",
     "name": "Purple Wool",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "purpur_block",
     "name": "Purpur Block",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "purpur_pillar",
     "name": "Purpur Pillar",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "purpur_slab",
     "name": "Purpur Slab",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "purpur_stairs",
     "name": "Purpur Stairs",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "quartz",
     "name": "Quartz",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "quartz_block",
     "name": "Quartz Block",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "quartz_bricks",
     "name": "Quartz Bricks",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "quartz_pillar",
     "name": "Quartz Pillar",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "quartz_slab",
     "name": "Quartz Slab",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "quartz_stairs",
     "name": "Quartz Stairs",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "rabbit",
     "name": "Rabbit",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "rabbit_foot",
     "name": "Rabbit Foot",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "rabbit_hide",
     "name": "Rabbit Hide",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "rabbit_spawn_egg",
     "name": "Rabbit Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "rabbit_stew",
     "name": "Rabbit Stew",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "rail",
     "name": "Rail",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "raiser_armor_trim_smithing_template",
     "name": "Raiser Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "ravager_spawn_egg",
     "name": "Ravager Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "raw_copper",
     "name": "Raw Copper",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "raw_copper_block",
     "name": "Raw Copper Block",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "raw_gold",
     "name": "Raw Gold",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "raw_gold_block",
     "name": "Raw Gold Block",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "raw_iron",
     "name": "Raw Iron",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "raw_iron_block",
     "name": "Raw Iron Block",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "recovery_compass",
     "name": "Recovery Compass",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "epic"
   },
   {
     "id": "red_banner",
     "name": "Red Banner",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "red_bed",
     "name": "Red Bed",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "red_candle",
     "name": "Red Candle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "red_carpet",
     "name": "Red Carpet",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "red_concrete",
     "name": "Red Concrete",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "red_concrete_powder",
     "name": "Red Concrete Powder",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "red_dye",
     "name": "Red Dye",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "red_glazed_terracotta",
     "name": "Red Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "red_mushroom",
     "name": "Red Mushroom",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "red_mushroom_block",
     "name": "Red Mushroom Block",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "red_nether_brick_slab",
     "name": "Red Nether Brick Slab",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "red_nether_brick_stairs",
     "name": "Red Nether Brick Stairs",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "red_nether_brick_wall",
     "name": "Red Nether Brick Wall",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "red_nether_bricks",
     "name": "Red Nether Bricks",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "red_sand",
     "name": "Red Sand",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "red_sandstone",
     "name": "Red Sandstone",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "red_sandstone_slab",
     "name": "Red Sandstone Slab",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "red_sandstone_stairs",
     "name": "Red Sandstone Stairs",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "red_sandstone_wall",
     "name": "Red Sandstone Wall",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "red_shulker_box",
     "name": "Red Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "red_stained_glass",
     "name": "Red Stained Glass",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "red_stained_glass_pane",
     "name": "Red Stained Glass Pane",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "red_terracotta",
     "name": "Red Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "red_tulip",
     "name": "Red Tulip",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "red_wool",
     "name": "Red Wool",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "redstone",
     "name": "Redstone",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "redstone_block",
     "name": "Redstone Block",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "redstone_lamp",
     "name": "Redstone Lamp",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "redstone_ore",
     "name": "Redstone Ore",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "redstone_torch",
     "name": "Redstone Torch",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "reinforced_deepslate",
     "name": "Reinforced Deepslate",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "repeater",
     "name": "Repeater",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "repeating_command_block",
     "name": "Repeating Command Block",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "respawn_anchor",
     "name": "Respawn Anchor",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "rib_armor_trim_smithing_template",
     "name": "Rib Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "rooted_dirt",
     "name": "Rooted Dirt",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "rose_bush",
     "name": "Rose Bush",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "rotten_flesh",
     "name": "Rotten Flesh",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "saddle",
     "name": "Saddle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "salmon",
     "name": "Salmon",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "salmon_bucket",
     "name": "Salmon Bucket",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "salmon_spawn_egg",
     "name": "Salmon Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "sand",
     "name": "Sand",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "sandstone",
     "name": "Sandstone",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "sandstone_slab",
     "name": "Sandstone Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "sandstone_stairs",
     "name": "Sandstone Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "sandstone_wall",
     "name": "Sandstone Wall",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "scaffolding",
     "name": "Scaffolding",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "sculk",
     "name": "Sculk",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "sculk_catalyst",
     "name": "Sculk Catalyst",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "sculk_sensor",
     "name": "Sculk Sensor",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "sculk_shrieker",
     "name": "Sculk Shrieker",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "sculk_vein",
     "name": "Sculk Vein",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "scute",
     "name": "Scute",
     "isEligible": false,
-    "category": "animals_loot"
+    "category": "animals_loot",
+    "rarity": "rare"
   },
   {
     "id": "sea_lantern",
     "name": "Sea Lantern",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "sea_pickle",
     "name": "Sea Pickle",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "seagrass",
     "name": "Seagrass",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "sentry_armor_trim_smithing_template",
     "name": "Sentry Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "shaper_armor_trim_smithing_template",
     "name": "Shaper Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "sheaf_pottery_sherd",
     "name": "Sheaf Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "shears",
     "name": "Shears",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "sheep_spawn_egg",
     "name": "Sheep Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "shelter_pottery_sherd",
     "name": "Shelter Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "shield",
     "name": "Shield",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "shroomlight",
     "name": "Shroomlight",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "shulker_box",
     "name": "Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "shulker_shell",
     "name": "Shulker Shell",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "shulker_spawn_egg",
     "name": "Shulker Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "silence_armor_trim_smithing_template",
     "name": "Silence Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "silverfish_spawn_egg",
     "name": "Silverfish Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "skeleton_horse_spawn_egg",
     "name": "Skeleton Horse Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "skeleton_skull",
     "name": "Skeleton Skull",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "skeleton_spawn_egg",
     "name": "Skeleton Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "skull_banner_pattern",
     "name": "Skull Banner Pattern",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "skull_pottery_sherd",
     "name": "Skull Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "slime_ball",
     "name": "Slime Ball",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "slime_block",
     "name": "Slime Block",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "slime_spawn_egg",
     "name": "Slime Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "small_amethyst_bud",
     "name": "Small Amethyst Bud",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "small_dripleaf",
     "name": "Small Dripleaf",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "smithing_table",
     "name": "Smithing Table",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "smoker",
     "name": "Smoker",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "smooth_basalt",
     "name": "Smooth Basalt",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "smooth_quartz",
     "name": "Smooth Quartz",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "smooth_quartz_slab",
     "name": "Smooth Quartz Slab",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "smooth_quartz_stairs",
     "name": "Smooth Quartz Stairs",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "smooth_red_sandstone",
     "name": "Smooth Red Sandstone",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "smooth_red_sandstone_slab",
     "name": "Smooth Red Sandstone Slab",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "smooth_red_sandstone_stairs",
     "name": "Smooth Red Sandstone Stairs",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "smooth_sandstone",
     "name": "Smooth Sandstone",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "smooth_sandstone_slab",
     "name": "Smooth Sandstone Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "smooth_sandstone_stairs",
     "name": "Smooth Sandstone Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "smooth_stone",
     "name": "Smooth Stone",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "smooth_stone_slab",
     "name": "Smooth Stone Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "sniffer_egg",
     "name": "Sniffer Egg",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "sniffer_spawn_egg",
     "name": "Sniffer Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "snort_pottery_sherd",
     "name": "Snort Pottery Sherd",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "snout_armor_trim_smithing_template",
     "name": "Snout Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "snow",
     "name": "Snow",
     "isEligible": false,
-    "category": "cold"
+    "category": "cold",
+    "rarity": "rare"
   },
   {
     "id": "snow_block",
     "name": "Snow Block",
     "isEligible": false,
-    "category": "cold"
+    "category": "cold",
+    "rarity": "rare"
   },
   {
     "id": "snow_golem_spawn_egg",
     "name": "Snow Golem Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "snowball",
     "name": "Snowball",
     "isEligible": false,
-    "category": "cold"
+    "category": "cold",
+    "rarity": "rare"
   },
   {
     "id": "soul_campfire",
     "name": "Soul Campfire",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "soul_lantern",
     "name": "Soul Lantern",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "soul_sand",
     "name": "Soul Sand",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "soul_soil",
     "name": "Soul Soil",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "soul_torch",
     "name": "Soul Torch",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "spawner",
     "name": "Spawner",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "spectral_arrow",
     "name": "Spectral Arrow",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "spider_eye",
     "name": "Spider Eye",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "spider_spawn_egg",
     "name": "Spider Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "spire_armor_trim_smithing_template",
     "name": "Spire Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "splash_potion",
     "name": "Splash Potion",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "sponge",
     "name": "Sponge",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "spore_blossom",
     "name": "Spore Blossom",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "spruce_boat",
     "name": "Spruce Boat",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_button",
     "name": "Spruce Button",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_chest_boat",
     "name": "Spruce Chest Boat",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_door",
     "name": "Spruce Door",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_fence",
     "name": "Spruce Fence",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_fence_gate",
     "name": "Spruce Fence Gate",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_hanging_sign",
     "name": "Spruce Hanging Sign",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_leaves",
     "name": "Spruce Leaves",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_log",
     "name": "Spruce Log",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_planks",
     "name": "Spruce Planks",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_pressure_plate",
     "name": "Spruce Pressure Plate",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_sapling",
     "name": "Spruce Sapling",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_sign",
     "name": "Spruce Sign",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_slab",
     "name": "Spruce Slab",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_stairs",
     "name": "Spruce Stairs",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_trapdoor",
     "name": "Spruce Trapdoor",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spruce_wood",
     "name": "Spruce Wood",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "spyglass",
     "name": "Spyglass",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "squid_spawn_egg",
     "name": "Squid Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "stick",
     "name": "Stick",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "sticky_piston",
     "name": "Sticky Piston",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "stone",
     "name": "Stone",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stone_axe",
     "name": "Stone Axe",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stone_brick_slab",
     "name": "Stone Brick Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stone_brick_stairs",
     "name": "Stone Brick Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stone_brick_wall",
     "name": "Stone Brick Wall",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stone_bricks",
     "name": "Stone Bricks",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stone_button",
     "name": "Stone Button",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stone_hoe",
     "name": "Stone Hoe",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stone_pickaxe",
     "name": "Stone Pickaxe",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stone_pressure_plate",
     "name": "Stone Pressure Plate",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stone_shovel",
     "name": "Stone Shovel",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stone_slab",
     "name": "Stone Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stone_stairs",
     "name": "Stone Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stone_sword",
     "name": "Stone Sword",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stonecutter",
     "name": "Stonecutter",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stray_spawn_egg",
     "name": "Stray Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "strider_spawn_egg",
     "name": "Strider Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "string",
     "name": "String",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "stripped_acacia_log",
     "name": "Stripped Acacia Log",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "stripped_acacia_wood",
     "name": "Stripped Acacia Wood",
     "isEligible": false,
-    "category": "savanna"
+    "category": "savanna",
+    "rarity": "common"
   },
   {
     "id": "stripped_bamboo_block",
     "name": "Stripped Bamboo Block",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "stripped_birch_log",
     "name": "Stripped Birch Log",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stripped_birch_wood",
     "name": "Stripped Birch Wood",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stripped_cherry_log",
     "name": "Stripped Cherry Log",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "stripped_cherry_wood",
     "name": "Stripped Cherry Wood",
     "isEligible": false,
-    "category": "cherry_grove"
+    "category": "cherry_grove",
+    "rarity": "rare"
   },
   {
     "id": "stripped_crimson_hyphae",
     "name": "Stripped Crimson Hyphae",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "stripped_crimson_stem",
     "name": "Stripped Crimson Stem",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "stripped_dark_oak_log",
     "name": "Stripped Dark Oak Log",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "stripped_dark_oak_wood",
     "name": "Stripped Dark Oak Wood",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "stripped_jungle_log",
     "name": "Stripped Jungle Log",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "stripped_jungle_wood",
     "name": "Stripped Jungle Wood",
     "isEligible": false,
-    "category": "jungle"
+    "category": "jungle",
+    "rarity": "rare"
   },
   {
     "id": "stripped_mangrove_log",
     "name": "Stripped Mangrove Log",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "stripped_mangrove_wood",
     "name": "Stripped Mangrove Wood",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "stripped_oak_log",
     "name": "Stripped Oak Log",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stripped_oak_wood",
     "name": "Stripped Oak Wood",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "stripped_spruce_log",
     "name": "Stripped Spruce Log",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "stripped_spruce_wood",
     "name": "Stripped Spruce Wood",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "stripped_warped_hyphae",
     "name": "Stripped Warped Hyphae",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "stripped_warped_stem",
     "name": "Stripped Warped Stem",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "structure_block",
     "name": "Structure Block",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "structure_void",
     "name": "Structure Void",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "sugar",
     "name": "Sugar",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "sugar_cane",
     "name": "Sugar Cane",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "sunflower",
     "name": "Sunflower",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "suspicious_gravel",
     "name": "Suspicious Gravel",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "suspicious_sand",
     "name": "Suspicious Sand",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "suspicious_stew",
     "name": "Suspicious Stew",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "sweet_berries",
     "name": "Sweet Berries",
     "isEligible": false,
-    "category": "taiga"
+    "category": "taiga",
+    "rarity": "common"
   },
   {
     "id": "tadpole_bucket",
     "name": "Tadpole Bucket",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "tadpole_spawn_egg",
     "name": "Tadpole Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "tall_grass",
     "name": "Tall Grass",
     "isEligible": false,
-    "category": "unobtainable"
+    "category": "unobtainable",
+    "rarity": "common"
   },
   {
     "id": "target",
     "name": "Target",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "terracotta",
     "name": "Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "tide_armor_trim_smithing_template",
     "name": "Tide Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "tinted_glass",
     "name": "Tinted Glass",
     "isEligible": false,
-    "category": "caves"
+    "category": "caves",
+    "rarity": "rare"
   },
   {
     "id": "tipped_arrow",
     "name": "Tipped Arrow",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "tnt",
     "name": "Tnt",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "tnt_minecart",
     "name": "Tnt Minecart",
     "isEligible": false,
-    "category": "enemy_loot"
+    "category": "enemy_loot",
+    "rarity": "rare"
   },
   {
     "id": "torch",
     "name": "Torch",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "torchflower",
     "name": "Torchflower",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "torchflower_seeds",
     "name": "Torchflower Seeds",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "totem_of_undying",
     "name": "Totem Of Undying",
     "isEligible": false,
-    "category": "dark_forest"
+    "category": "dark_forest",
+    "rarity": "rare"
   },
   {
     "id": "trader_llama_spawn_egg",
     "name": "Trader Llama Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "trapped_chest",
     "name": "Trapped Chest",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "trident",
     "name": "Trident",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "tripwire_hook",
     "name": "Tripwire Hook",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "tropical_fish",
     "name": "Tropical Fish",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "tropical_fish_bucket",
     "name": "Tropical Fish Bucket",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "tropical_fish_spawn_egg",
     "name": "Tropical Fish Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "tube_coral",
     "name": "Tube Coral",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "tube_coral_block",
     "name": "Tube Coral Block",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "tube_coral_fan",
     "name": "Tube Coral Fan",
     "isEligible": false,
-    "category": "silk_touch"
+    "category": "silk_touch",
+    "rarity": "rare"
   },
   {
     "id": "tuff",
     "name": "Tuff",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "turtle_egg",
     "name": "Turtle Egg",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "turtle_helmet",
     "name": "Turtle Helmet",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "turtle_spawn_egg",
     "name": "Turtle Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "twisting_vines",
     "name": "Twisting Vines",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "verdant_froglight",
     "name": "Verdant Froglight",
     "isEligible": false,
-    "category": "swamp"
+    "category": "swamp",
+    "rarity": "rare"
   },
   {
     "id": "vex_armor_trim_smithing_template",
     "name": "Vex Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "vex_spawn_egg",
     "name": "Vex Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "villager_spawn_egg",
     "name": "Villager Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "vindicator_spawn_egg",
     "name": "Vindicator Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "vine",
     "name": "Vine",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "wandering_trader_spawn_egg",
     "name": "Wandering Trader Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "ward_armor_trim_smithing_template",
     "name": "Ward Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "warden_spawn_egg",
     "name": "Warden Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "warped_button",
     "name": "Warped Button",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_door",
     "name": "Warped Door",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_fence",
     "name": "Warped Fence",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_fence_gate",
     "name": "Warped Fence Gate",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_fungus",
     "name": "Warped Fungus",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_fungus_on_a_stick",
     "name": "Warped Fungus On A Stick",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_hanging_sign",
     "name": "Warped Hanging Sign",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_hyphae",
     "name": "Warped Hyphae",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_nylium",
     "name": "Warped Nylium",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_planks",
     "name": "Warped Planks",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_pressure_plate",
     "name": "Warped Pressure Plate",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_roots",
     "name": "Warped Roots",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_sign",
     "name": "Warped Sign",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_slab",
     "name": "Warped Slab",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_stairs",
     "name": "Warped Stairs",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_stem",
     "name": "Warped Stem",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_trapdoor",
     "name": "Warped Trapdoor",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "warped_wart_block",
     "name": "Warped Wart Block",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "water_bucket",
     "name": "Water Bucket",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "wayfinder_armor_trim_smithing_template",
     "name": "Wayfinder Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "weathered_copper",
     "name": "Weathered Copper",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "weathered_cut_copper",
     "name": "Weathered Cut Copper",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "weathered_cut_copper_slab",
     "name": "Weathered Cut Copper Slab",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "weathered_cut_copper_stairs",
     "name": "Weathered Cut Copper Stairs",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "weeping_vines",
     "name": "Weeping Vines",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "wet_sponge",
     "name": "Wet Sponge",
     "isEligible": false,
-    "category": "ocean"
+    "category": "ocean",
+    "rarity": "rare"
   },
   {
     "id": "wheat",
     "name": "Wheat",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "wheat_seeds",
     "name": "Wheat Seeds",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "white_banner",
     "name": "White Banner",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "white_bed",
     "name": "White Bed",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "white_candle",
     "name": "White Candle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "white_carpet",
     "name": "White Carpet",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "white_concrete",
     "name": "White Concrete",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "white_concrete_powder",
     "name": "White Concrete Powder",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "white_dye",
     "name": "White Dye",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "white_glazed_terracotta",
     "name": "White Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "white_shulker_box",
     "name": "White Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "white_stained_glass",
     "name": "White Stained Glass",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "white_stained_glass_pane",
     "name": "White Stained Glass Pane",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "white_terracotta",
     "name": "White Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "white_tulip",
     "name": "White Tulip",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "white_wool",
     "name": "White Wool",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "wild_armor_trim_smithing_template",
     "name": "Wild Armor Trim Smithing Template",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "witch_spawn_egg",
     "name": "Witch Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "wither_rose",
     "name": "Wither Rose",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "wither_skeleton_skull",
     "name": "Wither Skeleton Skull",
     "isEligible": false,
-    "category": "nether"
+    "category": "nether",
+    "rarity": "rare"
   },
   {
     "id": "wither_skeleton_spawn_egg",
     "name": "Wither Skeleton Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "wither_spawn_egg",
     "name": "Wither Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "wolf_spawn_egg",
     "name": "Wolf Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "wooden_axe",
     "name": "Wooden Axe",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "wooden_hoe",
     "name": "Wooden Hoe",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "wooden_pickaxe",
     "name": "Wooden Pickaxe",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "wooden_shovel",
     "name": "Wooden Shovel",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "wooden_sword",
     "name": "Wooden Sword",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "writable_book",
     "name": "Writable Book",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "written_book",
     "name": "Written Book",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "yellow_banner",
     "name": "Yellow Banner",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "yellow_bed",
     "name": "Yellow Bed",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "yellow_candle",
     "name": "Yellow Candle",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "yellow_carpet",
     "name": "Yellow Carpet",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "yellow_concrete",
     "name": "Yellow Concrete",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "yellow_concrete_powder",
     "name": "Yellow Concrete Powder",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "yellow_dye",
     "name": "Yellow Dye",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "yellow_glazed_terracotta",
     "name": "Yellow Glazed Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "yellow_shulker_box",
     "name": "Yellow Shulker Box",
     "isEligible": false,
-    "category": "end"
+    "category": "end",
+    "rarity": "rare"
   },
   {
     "id": "yellow_stained_glass",
     "name": "Yellow Stained Glass",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "yellow_stained_glass_pane",
     "name": "Yellow Stained Glass Pane",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "yellow_terracotta",
     "name": "Yellow Terracotta",
     "isEligible": false,
-    "category": "messa"
+    "category": "messa",
+    "rarity": "common"
   },
   {
     "id": "yellow_wool",
     "name": "Yellow Wool",
     "isEligible": true,
-    "category": "universal"
+    "category": "universal",
+    "rarity": "common"
   },
   {
     "id": "zoglin_spawn_egg",
     "name": "Zoglin Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "zombie_head",
     "name": "Zombie Head",
     "isEligible": false,
-    "category": "treasure"
+    "category": "treasure",
+    "rarity": "rare"
   },
   {
     "id": "zombie_horse_spawn_egg",
     "name": "Zombie Horse Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "zombie_spawn_egg",
     "name": "Zombie Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "zombie_villager_spawn_egg",
     "name": "Zombie Villager Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   },
   {
     "id": "zombified_piglin_spawn_egg",
     "name": "Zombified Piglin Spawn Egg",
     "isEligible": false,
-    "category": "spawn_eggs"
+    "category": "spawn_eggs",
+    "rarity": "common"
   }
 ]

--- a/src/lib/components/bingo/generate-button.tsx
+++ b/src/lib/components/bingo/generate-button.tsx
@@ -19,11 +19,12 @@ export function encodeCardToParams(
 }
 
 export const GenerateButton = () => {
-  const { items, addToCardsHistory, cardsHistory } = useBoundStore(
+  const { items, addToCardsHistory, cardsHistory, raritySlots } = useBoundStore(
     useShallow((state) => ({
       items: state.items,
       addToCardsHistory: state.addToCardsHistory,
       cardsHistory: state.cardsHistory,
+      raritySlots: state.raritySlots,
     }))
   );
   const [spinning, setSpinning] = useState(false);
@@ -32,7 +33,8 @@ export const GenerateButton = () => {
   const handleGenerateAndSetCard = () => {
     setSpinning(true);
     const generatedCard = generateCard(
-      items.filter((item) => item.isEligible === true)
+      items.filter((item) => item.isEligible === true),
+      raritySlots
     );
     const title = `Card #${cardsHistory.length + 1}`;
     addToCardsHistory({

--- a/src/lib/components/items/filter-items.tsx
+++ b/src/lib/components/items/filter-items.tsx
@@ -27,6 +27,7 @@ export default function FilterItems() {
       defaultValue="all"
     >
       <ToggleGroupItem
+        className="whitespace-nowrap p-2"
         value="all"
         key={'all'}
         onClick={() => handleCategoryCLick(null)}
@@ -36,7 +37,7 @@ export default function FilterItems() {
       {categories.map((category) => {
         return (
           <ToggleGroupItem
-            className="whitespace-nowrap"
+            className="whitespace-nowrap p-2"
             onClick={() => handleCategoryCLick(category)}
             value={category}
             key={category}

--- a/src/lib/components/items/filter-items.tsx
+++ b/src/lib/components/items/filter-items.tsx
@@ -22,11 +22,9 @@ export default function FilterItems() {
 
   return (
     <ToggleGroup
-      className="justify-start"
+      className="justify-start py-1"
       type="single"
-      size="sm"
       defaultValue="all"
-      variant="outline"
     >
       <ToggleGroupItem
         value="all"

--- a/src/lib/components/items/items-list.tsx
+++ b/src/lib/components/items/items-list.tsx
@@ -10,9 +10,6 @@ import { Item as ItemType } from '@/lib/domain/items/types';
 import VirtualizedList from '../ui/virtualized-list';
 import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
 
-const pressAnimationClasses =
-  'translate-3d ring-2 ring-inset after:absolute after:h-full after:w-full after:rounded-md after:bg-primary after:transition-transform active:translate-y-1 relative data-[state=on]:translate-y-1 data-[state=on]:after:h-0';
-
 interface ItemsListProps {
   items: ItemType[];
   toggleEligibility: (id: string) => void;

--- a/src/lib/components/items/items-list.tsx
+++ b/src/lib/components/items/items-list.tsx
@@ -8,15 +8,21 @@ import {
 import { Switch } from '../ui/switch';
 import { Item as ItemType } from '@/lib/domain/items/types';
 import VirtualizedList from '../ui/virtualized-list';
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
+
+const pressAnimationClasses =
+  'translate-3d ring-2 ring-inset after:absolute after:h-full after:w-full after:rounded-md after:bg-primary after:transition-transform active:translate-y-1 relative data-[state=on]:translate-y-1 data-[state=on]:after:h-0';
 
 interface ItemsListProps {
   items: ItemType[];
   toggleEligibility: (id: string) => void;
+  setRarity: (id: string, rarity: ItemType['rarity']) => void;
 }
 
 export default function ItemsList({
   items,
   toggleEligibility,
+  setRarity,
 }: ItemsListProps) {
   return (
     <VirtualizedList
@@ -34,9 +40,41 @@ export default function ItemsList({
               <img src={`./items/${item.id}.png`} alt={item.name} />
             </ItemMedia>
             <ItemContent>
-              <ItemTitle>{item.name}</ItemTitle>
+              <ItemTitle className="flex-1 min-w-0 truncate">
+                {item.name}
+              </ItemTitle>
             </ItemContent>
             <ItemActions>
+              <ToggleGroup
+                type="single"
+                value={item.rarity}
+                onValueChange={(value) =>
+                  value && setRarity(item.id, value as ItemType['rarity'])
+                }
+              >
+                <ToggleGroupItem
+                  value="common"
+                  aria-label="Common"
+                  className="w-9 h-9 p-0"
+                >
+                  C
+                </ToggleGroupItem>
+                <ToggleGroupItem
+                  value="rare"
+                  aria-label="Rare"
+                  className="w-9 h-9 p-0"
+                >
+                  R
+                </ToggleGroupItem>
+                <ToggleGroupItem
+                  value="epic"
+                  aria-label="Epic"
+                  className="w-9 h-9 p-0"
+                >
+                  E
+                </ToggleGroupItem>
+              </ToggleGroup>
+
               <Switch
                 onCheckedChange={() => toggleEligibility(item.id)}
                 checked={item.isEligible}

--- a/src/lib/components/ui/cell.tsx
+++ b/src/lib/components/ui/cell.tsx
@@ -8,6 +8,12 @@ type CellProps = {
   disabled?: boolean;
 };
 
+const rarityRingColors: Record<Item['rarity'], string> = {
+  common: 'ring-stone-300 dark:ring-stone-700',
+  rare: 'ring-[#BA7517] dark:ring-[#BA7517]',
+  epic: 'ring-[#534AB7] dark:ring-[#534AB7]',
+};
+
 export const Cell = ({ item, checked, onClick, disabled }: CellProps) => {
   const { id, name } = item;
 
@@ -27,7 +33,7 @@ export const Cell = ({ item, checked, onClick, disabled }: CellProps) => {
       } style-preserve translate-3d flex items-center justify-center break-words transition-all active:translate-y-1`}
     >
       <div
-        className={`h-full w-full rounded-2xl bg-card p-3 ${checked ? 'opacity-30' : ''} ${disabled ? '' : 'ring-2 ring-inset ring-stone-300 dark:ring-stone-700'}`}
+        className={`h-full w-full rounded-2xl bg-card p-3 ${checked ? 'opacity-30' : ''} ${disabled ? '' : `ring-2 ring-inset ${rarityRingColors[item.rarity]}`}`}
       >
         <img
           src={`./items/${id}.png`}

--- a/src/lib/components/ui/item.tsx
+++ b/src/lib/components/ui/item.tsx
@@ -10,7 +10,10 @@ function ItemGroup({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       role="list"
       data-slot="item-group"
-      className={cn('group/item-group flex flex-col', className)}
+      className={cn(
+        'flex flex-1 flex-col gap-1 min-w-0 [&+[data-slot=item-content]]:flex-none',
+        className
+      )}
       {...props}
     />
   );

--- a/src/lib/components/ui/slider.tsx
+++ b/src/lib/components/ui/slider.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import * as SliderPrimitive from '@radix-ui/react-slider';
+
+import { cn } from '@/lib/styles/utils';
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn(
+      'relative flex w-full touch-none select-none items-center',
+      className
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-[4px] bg-secondary">
+      <SliderPrimitive.Range className="absolute h-full bg-rose-400" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-[6px] cursor-pointer border-2 border-border bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-400 focus-visible:ring-offset-2 focus-visible:border-white disabled:pointer-events-none disabled:opacity-50" />{' '}
+  </SliderPrimitive.Root>
+));
+Slider.displayName = SliderPrimitive.Root.displayName;
+
+export { Slider };

--- a/src/lib/components/ui/toggle-group.tsx
+++ b/src/lib/components/ui/toggle-group.tsx
@@ -2,59 +2,44 @@
 
 import * as React from 'react';
 import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
-import { type VariantProps } from 'class-variance-authority';
-
 import { cn } from '@/lib/styles/utils';
-import { toggleVariants } from '@/lib/components/ui/toggle';
 
-const ToggleGroupContext = React.createContext<
-  VariantProps<typeof toggleVariants>
->({
-  size: 'default',
-  variant: 'default',
-});
+const baseToggleClasses = cn(
+  'translate-3d ring-2 ring-inset after:absolute after:h-full after:w-full after:rounded-md after:bg-primary after:transition-transform active:translate-y-1 style-preserve relative inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+  'p-2',
+  'bg-secondary text-secondary-foreground ring-stone-300 dark:ring-stone-700 after:bg-stone-200 dark:after:bg-stone-800',
+  'data-[state=on]:translate-y-1 data-[state=on]:after:h-0 data-[state=on]:bg-secondary',
+  'data-[state=on]:translate-y-1',
+  'data-[state=on]:bg-accent data-[state=on]:text-accent-foreground data-[state=on]:ring-accent',
+  'data-[state=on]:after:h-0'
+);
 
 const ToggleGroup = React.forwardRef<
   React.ElementRef<typeof ToggleGroupPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
-    VariantProps<typeof toggleVariants>
->(({ className, variant, size, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root>
+>(({ className, ...props }, ref) => (
   <ToggleGroupPrimitive.Root
     ref={ref}
-    className={cn('flex items-center justify-center gap-1', className)}
+    className={cn(
+      'flex items-center justify-start gap-1 flex-shrink-0',
+      className
+    )}
     {...props}
-  >
-    <ToggleGroupContext.Provider value={{ variant, size }}>
-      {children}
-    </ToggleGroupContext.Provider>
-  </ToggleGroupPrimitive.Root>
+  />
 ));
 
 ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
 
 const ToggleGroupItem = React.forwardRef<
   React.ElementRef<typeof ToggleGroupPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
-    VariantProps<typeof toggleVariants>
->(({ className, children, variant, size, ...props }, ref) => {
-  const context = React.useContext(ToggleGroupContext);
-
-  return (
-    <ToggleGroupPrimitive.Item
-      ref={ref}
-      className={cn(
-        toggleVariants({
-          variant: context.variant || variant,
-          size: context.size || size,
-        }),
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </ToggleGroupPrimitive.Item>
-  );
-});
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <ToggleGroupPrimitive.Item
+    ref={ref}
+    className={cn(baseToggleClasses, className)}
+    {...props}
+  />
+));
 
 ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName;
 

--- a/src/lib/components/ui/toggle-group.tsx
+++ b/src/lib/components/ui/toggle-group.tsx
@@ -6,12 +6,8 @@ import { cn } from '@/lib/styles/utils';
 
 const baseToggleClasses = cn(
   'translate-3d ring-2 ring-inset after:absolute after:h-full after:w-full after:rounded-md after:bg-primary after:transition-transform active:translate-y-1 style-preserve relative inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
-  'p-2',
   'bg-secondary text-secondary-foreground ring-stone-300 dark:ring-stone-700 after:bg-stone-200 dark:after:bg-stone-800',
-  'data-[state=on]:translate-y-1 data-[state=on]:after:h-0 data-[state=on]:bg-secondary',
-  'data-[state=on]:translate-y-1',
-  'data-[state=on]:bg-accent data-[state=on]:text-accent-foreground data-[state=on]:ring-accent',
-  'data-[state=on]:after:h-0'
+  'data-[state=on]:translate-y-1 data-[state=on]:after:h-0 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground data-[state=on]:ring-accent'
 );
 
 const ToggleGroup = React.forwardRef<

--- a/src/lib/components/user-preferences/difficulty-dialog.tsx
+++ b/src/lib/components/user-preferences/difficulty-dialog.tsx
@@ -21,18 +21,18 @@ const PRESETS = [
 
 export function DifficultyDialog() {
   const { raritySlots, setRaritySlots } = useBoundStore();
-  const [isAdvanced, setIsAdvanced] = useState(false);
-
   const currentPresetIndex = PRESETS.findIndex(
     (p) => p.rare === raritySlots.rare && p.epic === raritySlots.epic
   );
 
+  const [isAdvanced, setIsAdvanced] = useState(currentPresetIndex === -1);
+
   useEffect(() => {
-    if (currentPresetIndex === -1) {
+    if (!isAdvanced && currentPresetIndex === -1) {
       setSliderValue(1);
       setRaritySlots(PRESETS[1]);
     }
-  }, [currentPresetIndex, setRaritySlots]);
+  }, [isAdvanced, currentPresetIndex, setRaritySlots]);
 
   const [sliderValue, setSliderValue] = useState(
     currentPresetIndex === -1 ? 1 : currentPresetIndex

--- a/src/lib/components/user-preferences/difficulty-dialog.tsx
+++ b/src/lib/components/user-preferences/difficulty-dialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useBoundStore } from '@/lib/zustand/store';
 import {
   DialogContent,
@@ -26,6 +26,14 @@ export function DifficultyDialog() {
   const currentPresetIndex = PRESETS.findIndex(
     (p) => p.rare === raritySlots.rare && p.epic === raritySlots.epic
   );
+
+  useEffect(() => {
+    if (currentPresetIndex === -1) {
+      setSliderValue(1);
+      setRaritySlots(PRESETS[1]);
+    }
+  }, [currentPresetIndex, setRaritySlots]);
+
   const [sliderValue, setSliderValue] = useState(
     currentPresetIndex === -1 ? 1 : currentPresetIndex
   );

--- a/src/lib/components/user-preferences/difficulty-dialog.tsx
+++ b/src/lib/components/user-preferences/difficulty-dialog.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { useBoundStore } from '@/lib/zustand/store';
+import {
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from '../ui/dialog';
+import { Slider } from '../ui/slider';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { Switch } from '../ui/switch';
+import { Button } from '../ui/button';
+
+const PRESETS = [
+  { rare: 2, epic: 0 },
+  { rare: 4, epic: 1 },
+  { rare: 8, epic: 2 },
+];
+
+export function DifficultyDialog() {
+  const { raritySlots, setRaritySlots } = useBoundStore();
+  const [isAdvanced, setIsAdvanced] = useState(false);
+
+  const currentPresetIndex = PRESETS.findIndex(
+    (p) => p.rare === raritySlots.rare && p.epic === raritySlots.epic
+  );
+  const [sliderValue, setSliderValue] = useState(
+    currentPresetIndex === -1 ? 1 : currentPresetIndex
+  );
+
+  const handleModeToggle = (checked: boolean) => {
+    setIsAdvanced(checked);
+    if (!checked) {
+      let minDistance = Infinity;
+      let closestIndex = 0;
+      PRESETS.forEach((p, index) => {
+        const distance = Math.sqrt(
+          Math.pow(raritySlots.rare - p.rare, 2) +
+            Math.pow(raritySlots.epic - p.epic, 2)
+        );
+        if (distance < minDistance) {
+          minDistance = distance;
+          closestIndex = index;
+        }
+      });
+      setSliderValue(closestIndex);
+      setRaritySlots(PRESETS[closestIndex]);
+    }
+  };
+
+  const handleSliderChange = (value: number[]) => {
+    const index = value[0];
+    setSliderValue(index);
+    setRaritySlots(PRESETS[index]);
+  };
+
+  const handleAdvancedChange = (key: 'rare' | 'epic', value: number) => {
+    const newSlots = { ...raritySlots, [key]: value };
+    if (
+      newSlots.rare + newSlots.epic <= 25 &&
+      newSlots.rare >= 0 &&
+      newSlots.epic >= 0
+    ) {
+      setRaritySlots(newSlots);
+    }
+  };
+
+  const common = 25 - raritySlots.rare - raritySlots.epic;
+
+  return (
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Difficulty</DialogTitle>
+        <DialogDescription>Adjust rarity distribution.</DialogDescription>
+      </DialogHeader>
+
+      <div className="flex items-center space-x-2">
+        <Label>Simple</Label>
+        <Switch checked={isAdvanced} onCheckedChange={handleModeToggle} />
+        <Label>Advanced</Label>
+      </div>
+
+      {!isAdvanced ? (
+        <div className="space-y-2">
+          <Slider
+            value={[sliderValue]}
+            min={0}
+            max={2}
+            step={1}
+            onValueChange={handleSliderChange}
+          />
+          <div className="flex justify-between px-1 text-xs text-muted-foreground">
+            <span>Easy</span>
+            <span>Normal</span>
+            <span>Hard</span>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="flex flex-col space-y-2">
+            <Label>Rare</Label>
+            <Input
+              type="number"
+              value={raritySlots.rare}
+              onChange={(e) =>
+                handleAdvancedChange('rare', parseInt(e.target.value) || 0)
+              }
+            />
+          </div>
+          <div className="flex flex-col space-y-2">
+            <Label>Epic</Label>
+            <Input
+              type="number"
+              value={raritySlots.epic}
+              onChange={(e) =>
+                handleAdvancedChange('epic', parseInt(e.target.value) || 0)
+              }
+            />
+          </div>
+          <div className="flex flex-col space-y-2">
+            <Label>Common (Read-only)</Label>
+            <Input value={common} readOnly />
+          </div>
+        </div>
+      )}
+      <DialogClose asChild>
+        <Button variant="secondary" className="w-full">
+          Close
+        </Button>
+      </DialogClose>
+    </DialogContent>
+  );
+}

--- a/src/lib/components/user-preferences/user-preferences-button.tsx
+++ b/src/lib/components/user-preferences/user-preferences-button.tsx
@@ -13,6 +13,8 @@ import {
 } from '../ui/dropdown-menu';
 import { Link } from 'react-router-dom';
 import { ModeToggleItems } from '../ui/mode-toggle';
+import { Dialog, DialogTrigger } from '../ui/dialog';
+import { DifficultyDialog } from './difficulty-dialog';
 
 export default function UserPreferencesButton() {
   return (
@@ -24,6 +26,15 @@ export default function UserPreferencesButton() {
       </DropdownMenuTrigger>
       <DropdownMenuContent>
         <DropdownMenuGroup>
+          <Dialog>
+            <DialogTrigger asChild>
+              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                Difficulty
+              </DropdownMenuItem>
+            </DialogTrigger>
+            <DifficultyDialog />
+          </Dialog>
+
           <DropdownMenuItem asChild>
             <Link to="/items">Edit Items</Link>
           </DropdownMenuItem>

--- a/src/lib/domain/card/generateCard.ts
+++ b/src/lib/domain/card/generateCard.ts
@@ -1,10 +1,44 @@
 import type { Item } from '../items/types';
+import type { PreferencesSlice } from '@/lib/zustand/preferencesSlice';
 
 export const BINGO_GRID_SIZE = 25;
 
-export default function generateCard(items: Item[]): Item[] {
-  return items
-    .slice()
-    .sort(() => Math.random() - 0.5)
-    .slice(0, BINGO_GRID_SIZE);
+export default function generateCard(
+  items: Item[],
+  raritySlots: PreferencesSlice['raritySlots']
+): Item[] {
+  const eligibleItems = items.filter((item) => item.isEligible);
+
+  const epicPool = eligibleItems
+    .filter((i) => i.rarity === 'epic')
+    .sort(() => Math.random() - 0.5);
+  const rarePool = eligibleItems
+    .filter((i) => i.rarity === 'rare')
+    .sort(() => Math.random() - 0.5);
+  const commonPool = eligibleItems
+    .filter((i) => i.rarity !== 'epic' && i.rarity !== 'rare')
+    .sort(() => Math.random() - 0.5);
+
+  const selectedItems: Item[] = [];
+
+  const targetEpic = Math.max(0, Math.min(raritySlots.epic, BINGO_GRID_SIZE));
+  const targetRare = Math.max(
+    0,
+    Math.min(raritySlots.rare, BINGO_GRID_SIZE - targetEpic)
+  );
+  const targetCommon = BINGO_GRID_SIZE - targetEpic - targetRare;
+
+  const fillTier = (pool: Item[], count: number) => {
+    const taken = pool.splice(0, count);
+    selectedItems.push(...taken);
+    return count - taken.length;
+  };
+
+  let remainingSlots = fillTier(epicPool, targetEpic);
+  remainingSlots = fillTier(rarePool, targetRare + remainingSlots);
+  fillTier(commonPool, targetCommon + remainingSlots);
+
+  return selectedItems
+    .slice(0, BINGO_GRID_SIZE)
+    .sort(() => Math.random() - 0.5);
 }

--- a/src/lib/domain/card/generateCard.ts
+++ b/src/lib/domain/card/generateCard.ts
@@ -16,7 +16,7 @@ export default function generateCard(
     .filter((i) => i.rarity === 'rare')
     .sort(() => Math.random() - 0.5);
   const commonPool = eligibleItems
-    .filter((i) => i.rarity !== 'epic' && i.rarity !== 'rare')
+    .filter((i) => i.rarity === 'common')
     .sort(() => Math.random() - 0.5);
 
   const selectedItems: Item[] = [];

--- a/src/lib/domain/items/types.ts
+++ b/src/lib/domain/items/types.ts
@@ -14,4 +14,5 @@ export type ItemsSlice = {
   resetItems: () => void;
   addItem: (item: NewItem) => void;
   setEligibilityByIds: (ids: string[], value: boolean) => void;
+  setRarity: (id: string, rarity: Item['rarity']) => void;
 };

--- a/src/lib/domain/items/types.ts
+++ b/src/lib/domain/items/types.ts
@@ -3,13 +3,10 @@ export type Item = {
   name: string;
   isEligible: boolean;
   category: string;
+  rarity: 'common' | 'rare' | 'epic';
 };
 
-export type NewItem = {
-  name: string;
-  isEligible: boolean;
-  category: string;
-};
+export type NewItem = Omit<Item, 'id'>;
 
 export type ItemsSlice = {
   items: Item[];

--- a/src/lib/domain/items/types.ts
+++ b/src/lib/domain/items/types.ts
@@ -6,12 +6,12 @@ export type Item = {
   rarity: 'common' | 'rare' | 'epic';
 };
 
-export type NewItem = Omit<Item, 'id'>;
+export type NewItem = Omit<Item, 'id' | 'rarity'> & { rarity?: Item['rarity'] };
 
 export type ItemsSlice = {
   items: Item[];
   toggleEligibility: (id: string) => void;
   resetItems: () => void;
-  addItem: (item: Item) => void;
+  addItem: (item: NewItem) => void;
   setEligibilityByIds: (ids: string[], value: boolean) => void;
 };

--- a/src/lib/pages/items/index.tsx
+++ b/src/lib/pages/items/index.tsx
@@ -11,7 +11,7 @@ import { useQueryState } from 'nuqs';
 export default function ItemsPage() {
   const [category] = useQueryState('category');
   const [query] = useQueryState('query');
-  const { items, toggleEligibility } = useBoundStore();
+  const { items, toggleEligibility, setRarity } = useBoundStore();
   const searchedItems = useSearchedItems(items, query);
   const filteredItems = useFilteredItems(searchedItems, category);
 
@@ -23,7 +23,11 @@ export default function ItemsPage() {
         right={<ResetItemsButton />}
       />
       <ItemsControl items={filteredItems} />
-      <ItemsList items={filteredItems} toggleEligibility={toggleEligibility} />
+      <ItemsList
+        items={filteredItems}
+        toggleEligibility={toggleEligibility}
+        setRarity={setRarity}
+      />
     </div>
   );
 }

--- a/src/lib/zustand/itemsSlice.ts
+++ b/src/lib/zustand/itemsSlice.ts
@@ -13,7 +13,10 @@ export const createItemsSlice: StateCreator<ItemsSlice> = (set, get) => ({
     if (get().items.some((i) => i.id === id))
       throw Error('Item already exists!');
 
-    const next = [...get().items, { ...item, name, id }];
+    const next = [
+      ...get().items,
+      { ...item, name, id, rarity: item.rarity ?? 'common' },
+    ];
     set({ items: next });
   },
   removeItem: (id: string) => {

--- a/src/lib/zustand/itemsSlice.ts
+++ b/src/lib/zustand/itemsSlice.ts
@@ -37,4 +37,10 @@ export const createItemsSlice: StateCreator<ItemsSlice> = (set, get) => ({
     if (!item) return;
     get().setEligibilityByIds([id], !item?.isEligible);
   },
+  setRarity: (id: string, rarity: Item['rarity']) => {
+    const next = get().items.map((item) =>
+      item.id === id ? { ...item, rarity } : item
+    );
+    set({ items: next });
+  },
 });

--- a/src/lib/zustand/preferencesSlice.ts
+++ b/src/lib/zustand/preferencesSlice.ts
@@ -1,0 +1,16 @@
+import { StateCreator } from 'zustand';
+
+export interface PreferencesSlice {
+  raritySlots: {
+    rare: number;
+    epic: number;
+  };
+  setRaritySlots: (slots: { rare: number; epic: number }) => void;
+}
+
+export const createPreferencesSlice: StateCreator<PreferencesSlice> = (
+  set
+) => ({
+  raritySlots: { rare: 4, epic: 1 },
+  setRaritySlots: (slots) => set({ raritySlots: slots }),
+});

--- a/src/lib/zustand/store.ts
+++ b/src/lib/zustand/store.ts
@@ -3,20 +3,23 @@ import { persist } from 'zustand/middleware';
 import { createItemsSlice } from './itemsSlice';
 import { ItemsSlice } from '../domain/items/types';
 import { CardsHistorySlice, createCardHistorySlice } from './cardsHistorySlice';
+import { PreferencesSlice, createPreferencesSlice } from './preferencesSlice';
 
-export type BoundStore = ItemsSlice & CardsHistorySlice;
+export type BoundStore = ItemsSlice & CardsHistorySlice & PreferencesSlice;
 
 export const useBoundStore = create<BoundStore>()(
   persist(
     (...a) => ({
       ...createItemsSlice(...a),
       ...createCardHistorySlice(...a),
+      ...createPreferencesSlice(...a),
     }),
     {
       name: 'skattjakt-storage',
       partialize: (state) => ({
         items: state.items,
         cardsHistory: state.cardsHistory,
+        raritySlots: state.raritySlots,
       }),
     }
   )


### PR DESCRIPTION
## What
Adds an item rarity system (common/rare/epic) with a difficulty dialog that controls how many rare and epic items appear on generated bingo cards.

## Why
Card generation previously sampled randomly from all eligible items with no way to balance how often valuable items show up, so difficulty couldn't be tuned.

## How
- Add a `rarity` field to every entry in `src/lib/api/items.json` and to `Item` (`src/lib/domain/items/types.ts`), plus a `setRarity` action in `ItemsSlice`
- Rewrite `generateCard` (`src/lib/domain/card/generateCard.ts`) to draw from separate epic/rare/common pools sized by a configurable `raritySlots`, falling back to lower tiers when a pool runs short
- Add `PreferencesSlice` (`src/lib/zustand/preferencesSlice.ts`) to store and persist `raritySlots`, merged into `useBoundStore`
- Add `DifficultyDialog` with an Easy/Normal/Hard preset slider (new `Slider` component) or advanced manual rare/epic counts, accessible from `UserPreferencesButton`
- Add per-item rarity toggles (Common/Rare/Epic) to `ItemsList`, and color-code `Cell` ring borders by rarity
- Simplify `ToggleGroup`/`ToggleGroupItem` to a single fixed style (drop the variant/size context) and adjust `FilterItems` spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Item rarity system: Assign common, rare, or epic rarity levels to items
  * Difficulty dialog: Configure rarity distributions via presets or manual editing
  * Rarity-aware card generation: Bingo cards now respect your rarity preferences

* **UI Improvements**
  * Enhanced component styling for improved layout and consistency
  * Color-coded visual indicators for item rarity values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->